### PR TITLE
 生成先を指定できるようにする #53 

### DIFF
--- a/client_generator/client_generator.go
+++ b/client_generator/client_generator.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"text/template"
 
@@ -38,6 +39,7 @@ type clientGenerator struct {
 	Imports    []importType
 	clientType
 	ChildrenClients []*clientType
+	OutputDir       string
 }
 
 func (g *clientGenerator) generate() error {
@@ -60,7 +62,8 @@ func (g *clientGenerator) generate() error {
 
 	t := template.Must(template.New("tmpl").Parse(string(templ)))
 
-	fp, err := os.Create("api_client.ts")
+	apiTsPath := filepath.Join(g.OutputDir, "./api_client.ts")
+	fp, err := os.Create(apiTsPath)
 
 	if err != nil {
 		log.Fatalf("failed to create api_client.ts: %+v", err)

--- a/client_generator/main.go
+++ b/client_generator/main.go
@@ -357,7 +357,7 @@ func main() {
 
 	var stat os.FileInfo
 	if stat, err = os.Stat(outputFullPath); err != nil {
-		if err := os.MkdirAll(outputFullPath, 0774); err != nil {
+		if err = os.MkdirAll(outputFullPath, 0774); err != nil {
 			log.Fatalf("failed to MkdirAll: %+v", err)
 		}
 	} else if !stat.IsDir() {

--- a/client_generator/main.go
+++ b/client_generator/main.go
@@ -355,7 +355,8 @@ func main() {
 		log.Fatalf("failed to run filepath.Abs: %+v", err)
 	}
 
-	if stat, err := os.Stat(outputFullPath); err != nil {
+	var stat os.FileInfo
+	if stat, err = os.Stat(outputFullPath); err != nil {
 		if err := os.MkdirAll(outputFullPath, 0774); err != nil {
 			log.Fatalf("failed to MkdirAll: %+v", err)
 		}
@@ -366,10 +367,10 @@ func main() {
 	log.Printf("output dir: %s", outputFullPath)
 	classesDir := filepath.Join(outputFullPath, "./classes")
 
-	if err := os.RemoveAll(classesDir); err != nil {
+	if err = os.RemoveAll(classesDir); err != nil {
 		log.Fatalf("failed to run RemoveAll: %+v", err)
 	}
-	if err := os.MkdirAll(classesDir, 0774); err != nil {
+	if err = os.MkdirAll(classesDir, 0774); err != nil {
 		log.Fatalf("failed to run MkdirAll: %+v", err)
 	}
 

--- a/client_generator/main.go
+++ b/client_generator/main.go
@@ -279,18 +279,23 @@ func walk(p, url string, generator *clientGenerator, parent *clientType) {
 		log.Fatalf("failed to get package: %+v", err)
 	}
 
+	classesDir := filepath.Join(generator.OutputDir, "./classes/")
+
 	if len(pkgParser.structs) != 0 {
-		if err = os.MkdirAll("./classes/"+url, 0774); err != nil {
+		if err = os.MkdirAll(classesDir+url, 0774); err != nil {
 			log.Fatalf("failed to MkdirAll: %+v", err)
 		}
 	}
 
 	var b []byte
 	for i := range pkgParser.structs {
+		structFilePath := filepath.Join(classesDir,
+			fmt.Sprintf("/%s/", url),
+			fmt.Sprintf("/%s.ts", pkgParser.structs[i]))
 		b, err = exec.Command(
 			"struct2ts",
 			"-o",
-			"./classes/"+url+"/"+pkgParser.structs[i]+".ts",
+			structFilePath,
 			goPkg+"."+pkgParser.structs[i],
 		).CombinedOutput()
 
@@ -336,6 +341,7 @@ func main() {
 	}
 
 	versionFlag := flag.Bool("v", false, "print version")
+	outputDir := flag.String("o", "./", "output directory of generated codes")
 
 	flag.Parse()
 
@@ -344,18 +350,37 @@ func main() {
 		return
 	}
 
-	if err := os.RemoveAll("./classes"); err != nil {
+	outputFullPath, err := filepath.Abs(*outputDir)
+	if err != nil {
+		log.Fatalf("failed to run filepath.Abs: %+v", err)
+	}
+
+	stat, err := os.Stat(outputFullPath)
+	if err != nil {
+		if err := os.MkdirAll(outputFullPath, 0774); err != nil {
+			log.Fatalf("failed to MkdirAll: %+v", err)
+		}
+	}
+	if err == nil && !stat.IsDir() {
+		log.Fatalf("-o specified is not a directory")
+	}
+
+	log.Printf("output dir: %s", outputFullPath)
+	classesDir := filepath.Join(outputFullPath, "./classes")
+
+	if err := os.RemoveAll(classesDir); err != nil {
 		log.Fatalf("failed to run RemoveAll: %+v", err)
 	}
-	if err := os.MkdirAll("./classes", 0774); err != nil {
+	if err := os.MkdirAll(classesDir, 0774); err != nil {
 		log.Fatalf("failed to run MkdirAll: %+v", err)
 	}
 
 	generator := &clientGenerator{
 		AppVersion: common.AppVersion,
+		OutputDir:  outputFullPath,
 	}
 
-	fullPath, err := filepath.Abs(os.Args[1])
+	fullPath, err := filepath.Abs(flag.Arg(0))
 	if err != nil {
 		log.Fatalf("failed to run filepath.Abs: %+v", err)
 	}

--- a/client_generator/main.go
+++ b/client_generator/main.go
@@ -355,13 +355,11 @@ func main() {
 		log.Fatalf("failed to run filepath.Abs: %+v", err)
 	}
 
-	stat, err := os.Stat(outputFullPath)
-	if err != nil {
+	if stat, err := os.Stat(outputFullPath); err != nil {
 		if err := os.MkdirAll(outputFullPath, 0774); err != nil {
 			log.Fatalf("failed to MkdirAll: %+v", err)
 		}
-	}
-	if err == nil && !stat.IsDir() {
+	} else if !stat.IsDir() {
 		log.Fatalf("-o specified is not a directory")
 	}
 


### PR DESCRIPTION
`client_generator` の方に `-o` オプションで生成先を指定できるようにしました。
`server_generator` の方はgoのpackage周りの問題があるため、出力先の指定は追加していません。
#48 も完了してからバージョンの方は更新する予定です。