### PR TITLE
Update Go version to v1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
       GO111MODULE: on
 
     steps:
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
       id: go
     
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Run GoReleaser for client_generator
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/statik.yml
+++ b/.github/workflows/statik.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - name: Set up Go 1.12
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.12
+          go-version: 1.16
         id: go
 
       - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-generalize/api_gen
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-generalize/go2ts v1.0.4


### PR DESCRIPTION
Go 1.16 has been released! :tada:
https://blog.golang.org/go1.16

This pull request allows us to use embed.FS #135 