### PR TITLE
Fix a bug that generated code is not formatted

### DIFF
--- a/pkg/server/controller_initializer.go
+++ b/pkg/server/controller_initializer.go
@@ -19,7 +19,7 @@ func (g *Generator) generateControllerInitializer(initializerPath, propsPackage 
 	defer fp.Close()
 
 	buf := bytes.NewBuffer(nil)
-	if err := g.controllerInitializerTemplate.Execute(fp, map[string]string{
+	if err := g.controllerInitializerTemplate.Execute(buf, map[string]string{
 		"ControllerPropsPackage": propsPackage,
 		"Package":                g.basePackage,
 		"AppVersion":             g.AppVersion,

--- a/pkg/server/props.go
+++ b/pkg/server/props.go
@@ -29,7 +29,7 @@ func (g *Generator) generateProps(propsPath string) error {
 	defer fp.Close()
 
 	buf := bytes.NewBuffer(nil)
-	if err := g.propsTemplate.Execute(fp, nil); err != nil {
+	if err := g.propsTemplate.Execute(buf, nil); err != nil {
 		return xerrors.Errorf("failed to execute template: %w", err)
 	}
 


### PR DESCRIPTION
`format.Source` を読んでいるのにただの空を渡してしまっていたので修正