### PR TITLE
Fix error log/response

### DIFF
--- a/pkg/server/templates/apierror_template.go.tmpl
+++ b/pkg/server/templates/apierror_template.go.tmpl
@@ -4,6 +4,7 @@ package apierror
 
 import (
 	"fmt"
+	"net/http"
 
 	"{{ .XerrorsPackage }}"
 )
@@ -18,13 +19,19 @@ type APIError struct {
 // NewAPIError - constructor
 func NewAPIError(status int, bodies ...interface{}) *APIError {
 	ae := &APIError{Status: status}
-	if length := len(bodies); length > 0 {
-		if length == 1 {
-			ae.Body = bodies[0]
-		} else {
-			ae.Body = bodies
+
+	switch len(bodies) {
+	case 0:
+		ae.Body = map[string]interface{} {
+			"code": status,
+			"message": http.StatusText(status),
 		}
+	case 1:
+		ae.Body = bodies[0]
+	default:
+		ae.Body = bodies
 	}
+
 	return ae
 }
 

--- a/pkg/server/templates/controller_bundler_template.go.tmpl
+++ b/pkg/server/templates/controller_bundler_template.go.tmpl
@@ -43,8 +43,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
         ctrl := {{ $elem.ControllerImportAlias }}.{{ $elem.ControllerInitializer }}(p)
 
         add("{{ $elem.Method }}", "{{ $elem.Path }}", func(c echo.Context) (interface{}, error) {
-            var werr *apierror.APIError
-
             req := new({{ $elem.TypesImportAlias }}.{{ $elem.RequestStructName }})
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for ({{ $elem.Path }}): %+v", err)
@@ -54,18 +52,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
             res, err := ctrl.{{ $elem.HandlerName }}(c, req)
 
             if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
                 return nil, xerrors.Errorf("{{ $elem.HandlerName }} returned an error: %w", err)
             }
 

--- a/pkg/server/templates/controller_bundler_template.go.tmpl
+++ b/pkg/server/templates/controller_bundler_template.go.tmpl
@@ -52,7 +52,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
             res, err := ctrl.{{ $elem.HandlerName }}(c, req)

--- a/pkg/server/templates/controller_bundler_template.go.tmpl
+++ b/pkg/server/templates/controller_bundler_template.go.tmpl
@@ -52,13 +52,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
             res, err := ctrl.{{ $elem.HandlerName }}(c, req)
 
             if err != nil {
-                return nil, xerrors.Errorf("{{ $elem.HandlerName }} returned an error: %w", err)
+                return nil, xerrors.Errorf("the handler({{ $elem.HandlerName }}) returned an error: %w", err)
             }
 
             if res == nil {

--- a/samples/empty_root/server/bundler.go
+++ b/samples/empty_root/server/bundler.go
@@ -42,8 +42,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_bar_ab9de98c.NewPostUserController(p)
 
 		add("POST", "/foo/bar/user", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_bar_8619c483.PostUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/foo/bar/user): %+v", err)
@@ -53,18 +51,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUser returned an error: %w", err)
 			}
 

--- a/samples/empty_root/server/bundler.go
+++ b/samples/empty_root/server/bundler.go
@@ -51,13 +51,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUser) returned an error: %w", err)
 			}
 
 			if res == nil {

--- a/samples/empty_root/server/bundler.go
+++ b/samples/empty_root/server/bundler.go
@@ -51,7 +51,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUser(c, req)

--- a/samples/empty_root/server/mock_bundler.go
+++ b/samples/empty_root/server/mock_bundler.go
@@ -51,13 +51,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUser) returned an error: %w", err)
 			}
 
 			if res == nil {

--- a/samples/empty_root/server/mock_bundler.go
+++ b/samples/empty_root/server/mock_bundler.go
@@ -42,8 +42,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_bar_8bd5d3ca.NewPostUserController(p)
 
 		add("POST", "/foo/bar/user", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_bar_8619c483.PostUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/foo/bar/user): %+v", err)
@@ -53,18 +51,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUser returned an error: %w", err)
 			}
 

--- a/samples/empty_root/server/mock_bundler.go
+++ b/samples/empty_root/server/mock_bundler.go
@@ -51,7 +51,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUser(c, req)

--- a/samples/empty_root/server/pkg/apierror/apierror.go
+++ b/samples/empty_root/server/pkg/apierror/apierror.go
@@ -4,6 +4,7 @@ package apierror
 
 import (
 	"fmt"
+	"net/http"
 
 	"golang.org/x/xerrors"
 )
@@ -18,13 +19,19 @@ type APIError struct {
 // NewAPIError - constructor
 func NewAPIError(status int, bodies ...interface{}) *APIError {
 	ae := &APIError{Status: status}
-	if length := len(bodies); length > 0 {
-		if length == 1 {
-			ae.Body = bodies[0]
-		} else {
-			ae.Body = bodies
+
+	switch len(bodies) {
+	case 0:
+		ae.Body = map[string]interface{}{
+			"code":    status,
+			"message": http.StatusText(status),
 		}
+	case 1:
+		ae.Body = bodies[0]
+	default:
+		ae.Body = bodies
 	}
+
 	return ae
 }
 

--- a/samples/standard/server/bundler.go
+++ b/samples/standard/server/bundler.go
@@ -63,7 +63,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
@@ -93,7 +93,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
@@ -123,7 +123,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
@@ -153,7 +153,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetArticle(c, req)
@@ -183,7 +183,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
@@ -213,7 +213,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
@@ -243,7 +243,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
@@ -273,7 +273,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
@@ -303,7 +303,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
@@ -333,7 +333,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUser(c, req)
@@ -363,7 +363,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
@@ -393,7 +393,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
@@ -423,7 +423,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
@@ -453,7 +453,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PutJob(c, req)

--- a/samples/standard/server/bundler.go
+++ b/samples/standard/server/bundler.go
@@ -63,13 +63,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("Get returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(Get) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -93,13 +93,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostCreateTable returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostCreateTable) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -123,13 +123,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostCreateUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostCreateUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -153,13 +153,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetArticle(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetArticle returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetArticle) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -183,13 +183,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetStaticPage returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetStaticPage) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -213,13 +213,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("Get returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(Get) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -243,13 +243,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserName) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -273,13 +273,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserPassword) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -303,13 +303,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("DeleteUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(DeleteUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -333,13 +333,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -363,13 +363,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserName) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -393,13 +393,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserPassword) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -423,13 +423,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetUserJobGet returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetUserJobGet) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -453,13 +453,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PutJob(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PutJob returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PutJob) returned an error: %w", err)
 			}
 
 			if res == nil {

--- a/samples/standard/server/bundler.go
+++ b/samples/standard/server/bundler.go
@@ -54,8 +54,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_c315c236.NewGetController(p)
 
 		add("GET", "/", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.GetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/): %+v", err)
@@ -65,18 +63,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("Get returned an error: %w", err)
 			}
 
@@ -92,8 +84,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_c315c236.NewPostCreateTableController(p)
 
 		add("POST", "/create_table", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.PostCreateTableRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/create_table): %+v", err)
@@ -103,18 +93,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostCreateTable returned an error: %w", err)
 			}
 
@@ -130,8 +114,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_c315c236.NewPostCreateUserController(p)
 
 		add("POST", "/create_user", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.PostCreateUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/create_user): %+v", err)
@@ -141,18 +123,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostCreateUser returned an error: %w", err)
 			}
 
@@ -168,8 +144,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_service_679ee266.NewGetArticleController(p)
 
 		add("GET", "/service/article", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_service_9e7a8e17.GetArticleRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/article): %+v", err)
@@ -179,18 +153,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetArticle(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetArticle returned an error: %w", err)
 			}
 
@@ -206,8 +174,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_static_page_b260e151.NewGetStaticPageController(p)
 
 		add("GET", "/service/static_page/static_page", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_static_page_de0aba5f.GetStaticPageRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/static_page/static_page): %+v", err)
@@ -217,18 +183,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetStaticPage returned an error: %w", err)
 			}
 
@@ -244,8 +204,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e0f28ce4.NewGetController(p)
 
 		add("GET", "/service/user/", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.GetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/): %+v", err)
@@ -255,18 +213,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("Get returned an error: %w", err)
 			}
 
@@ -282,8 +234,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e0f28ce4.NewPostUpdateUserNameController(p)
 
 		add("POST", "/service/user/update_user_name", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.PostUpdateUserNameRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/update_user_name): %+v", err)
@@ -293,18 +243,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
 			}
 
@@ -320,8 +264,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e0f28ce4.NewPostUpdateUserPasswordController(p)
 
 		add("POST", "/service/user/update_user_password", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.PostUpdateUserPasswordRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/update_user_password): %+v", err)
@@ -331,18 +273,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
 			}
 
@@ -358,8 +294,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_7d7519cf.NewDeleteUserController(p)
 
 		add("DELETE", "/service/user2/:user_id", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.DeleteUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:user_id): %+v", err)
@@ -369,18 +303,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("DeleteUser returned an error: %w", err)
 			}
 
@@ -396,8 +324,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_7d7519cf.NewGetUserController(p)
 
 		add("GET", "/service/user2/:user_id", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.GetUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:user_id): %+v", err)
@@ -407,18 +333,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetUser returned an error: %w", err)
 			}
 
@@ -434,8 +354,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_7d7519cf.NewPostUpdateUserNameController(p)
 
 		add("POST", "/service/user2/update_user_name", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.PostUpdateUserNameRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/update_user_name): %+v", err)
@@ -445,18 +363,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
 			}
 
@@ -472,8 +384,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_7d7519cf.NewPostUpdateUserPasswordController(p)
 
 		add("POST", "/service/user2/update_user_password", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.PostUpdateUserPasswordRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/update_user_password): %+v", err)
@@ -483,18 +393,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
 			}
 
@@ -510,8 +414,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl__userID_2143b3b9.NewGetUserJobGetController(p)
 
 		add("GET", "/service/user2/:userID/user_job_get", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types__userID_c13e838d.GetUserJobGetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:userID/user_job_get): %+v", err)
@@ -521,18 +423,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetUserJobGet returned an error: %w", err)
 			}
 
@@ -548,8 +444,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl__JobID_f06f080e.NewPutJobController(p)
 
 		add("PUT", "/service/user2/:userID/:JobID/job", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types__JobID_3469130f.PutJobRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:userID/:JobID/job): %+v", err)
@@ -559,18 +453,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PutJob(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PutJob returned an error: %w", err)
 			}
 

--- a/samples/standard/server/mock_bundler.go
+++ b/samples/standard/server/mock_bundler.go
@@ -54,8 +54,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_12c43f8d.NewGetController(p)
 
 		add("GET", "/", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.GetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/): %+v", err)
@@ -65,18 +63,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("Get returned an error: %w", err)
 			}
 
@@ -92,8 +84,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_12c43f8d.NewPostCreateTableController(p)
 
 		add("POST", "/create_table", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.PostCreateTableRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/create_table): %+v", err)
@@ -103,18 +93,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostCreateTable returned an error: %w", err)
 			}
 
@@ -130,8 +114,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_controller_12c43f8d.NewPostCreateUserController(p)
 
 		add("POST", "/create_user", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_api_0b9a5e6c.PostCreateUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/create_user): %+v", err)
@@ -141,18 +123,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostCreateUser returned an error: %w", err)
 			}
 
@@ -168,8 +144,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_service_61e5de06.NewGetArticleController(p)
 
 		add("GET", "/service/article", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_service_9e7a8e17.GetArticleRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/article): %+v", err)
@@ -179,18 +153,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetArticle(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetArticle returned an error: %w", err)
 			}
 
@@ -206,8 +174,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_static_page_87ad62fe.NewGetStaticPageController(p)
 
 		add("GET", "/service/static_page/static_page", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_static_page_de0aba5f.GetStaticPageRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/static_page/static_page): %+v", err)
@@ -217,18 +183,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetStaticPage returned an error: %w", err)
 			}
 
@@ -244,8 +204,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e4c8f2cf.NewGetController(p)
 
 		add("GET", "/service/user/", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.GetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/): %+v", err)
@@ -255,18 +213,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("Get returned an error: %w", err)
 			}
 
@@ -282,8 +234,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e4c8f2cf.NewPostUpdateUserNameController(p)
 
 		add("POST", "/service/user/update_user_name", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.PostUpdateUserNameRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/update_user_name): %+v", err)
@@ -293,18 +243,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
 			}
 
@@ -320,8 +264,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user_e4c8f2cf.NewPostUpdateUserPasswordController(p)
 
 		add("POST", "/service/user/update_user_password", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user_256eedda.PostUpdateUserPasswordRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user/update_user_password): %+v", err)
@@ -331,18 +273,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
 			}
 
@@ -358,8 +294,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_2348a599.NewDeleteUserController(p)
 
 		add("DELETE", "/service/user2/:user_id", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.DeleteUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:user_id): %+v", err)
@@ -369,18 +303,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("DeleteUser returned an error: %w", err)
 			}
 
@@ -396,8 +324,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_2348a599.NewGetUserController(p)
 
 		add("GET", "/service/user2/:user_id", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.GetUserRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:user_id): %+v", err)
@@ -407,18 +333,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetUser(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetUser returned an error: %w", err)
 			}
 
@@ -434,8 +354,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_2348a599.NewPostUpdateUserNameController(p)
 
 		add("POST", "/service/user2/update_user_name", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.PostUpdateUserNameRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/update_user_name): %+v", err)
@@ -445,18 +363,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
 			}
 
@@ -472,8 +384,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl_user2_2348a599.NewPostUpdateUserPasswordController(p)
 
 		add("POST", "/service/user2/update_user_password", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types_user2_058d5a8a.PostUpdateUserPasswordRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/update_user_password): %+v", err)
@@ -483,18 +393,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
 			}
 
@@ -510,8 +414,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl__userID_145a08ca.NewGetUserJobGetController(p)
 
 		add("GET", "/service/user2/:userID/user_job_get", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types__userID_c13e838d.GetUserJobGetRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:userID/user_job_get): %+v", err)
@@ -521,18 +423,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("GetUserJobGet returned an error: %w", err)
 			}
 
@@ -548,8 +444,6 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 		ctrl := ctrl__JobID_59b29e1f.NewPutJobController(p)
 
 		add("PUT", "/service/user2/:userID/:JobID/job", func(c echo.Context) (interface{}, error) {
-			var werr *apierror.APIError
-
 			req := new(types__JobID_3469130f.PutJobRequest)
 			if err := c.Bind(req); err != nil {
 				c.Logger().Errorf("failed to bind a request for (/service/user2/:userID/:JobID/job): %+v", err)
@@ -559,18 +453,12 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, err
 			}
 
 			res, err := ctrl.PutJob(c, req)
 
 			if err != nil {
-				if xerrors.As(err, &werr) {
-					return nil, c.JSON(werr.Status, werr.Body)
-				}
 				return nil, xerrors.Errorf("PutJob returned an error: %w", err)
 			}
 

--- a/samples/standard/server/mock_bundler.go
+++ b/samples/standard/server/mock_bundler.go
@@ -63,7 +63,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
@@ -93,7 +93,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
@@ -123,7 +123,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
@@ -153,7 +153,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetArticle(c, req)
@@ -183,7 +183,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
@@ -213,7 +213,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
@@ -243,7 +243,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
@@ -273,7 +273,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
@@ -303,7 +303,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
@@ -333,7 +333,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUser(c, req)
@@ -363,7 +363,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
@@ -393,7 +393,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
@@ -423,7 +423,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
@@ -453,7 +453,7 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, err
+				return nil, xerrors.Errorf("Validate returned an error: %w", err)
 			}
 
 			res, err := ctrl.PutJob(c, req)

--- a/samples/standard/server/mock_bundler.go
+++ b/samples/standard/server/mock_bundler.go
@@ -63,13 +63,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("Get returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(Get) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -93,13 +93,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateTable(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostCreateTable returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostCreateTable) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -123,13 +123,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostCreateUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostCreateUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostCreateUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -153,13 +153,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetArticle(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetArticle returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetArticle) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -183,13 +183,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetStaticPage(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetStaticPage returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetStaticPage) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -213,13 +213,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.Get(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("Get returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(Get) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -243,13 +243,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserName) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -273,13 +273,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserPassword) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -303,13 +303,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.DeleteUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("DeleteUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(DeleteUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -333,13 +333,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUser(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetUser returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetUser) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -363,13 +363,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserName(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserName returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserName) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -393,13 +393,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PostUpdateUserPassword(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PostUpdateUserPassword returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PostUpdateUserPassword) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -423,13 +423,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.GetUserJobGet(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("GetUserJobGet returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(GetUserJobGet) returned an error: %w", err)
 			}
 
 			if res == nil {
@@ -453,13 +453,13 @@ func addRoutes(e *echo.Echo, p *props.ControllerProps) {
 				})
 			}
 			if err := c.Validate(req); err != nil && err != echo.ErrValidatorNotRegistered {
-				return nil, xerrors.Errorf("Validate returned an error: %w", err)
+				return nil, xerrors.Errorf("the validator returned an error: %w", err)
 			}
 
 			res, err := ctrl.PutJob(c, req)
 
 			if err != nil {
-				return nil, xerrors.Errorf("PutJob returned an error: %w", err)
+				return nil, xerrors.Errorf("the handler(PutJob) returned an error: %w", err)
 			}
 
 			if res == nil {

--- a/samples/standard/server/pkg/apierror/apierror.go
+++ b/samples/standard/server/pkg/apierror/apierror.go
@@ -4,6 +4,7 @@ package apierror
 
 import (
 	"fmt"
+	"net/http"
 
 	"golang.org/x/xerrors"
 )
@@ -18,13 +19,19 @@ type APIError struct {
 // NewAPIError - constructor
 func NewAPIError(status int, bodies ...interface{}) *APIError {
 	ae := &APIError{Status: status}
-	if length := len(bodies); length > 0 {
-		if length == 1 {
-			ae.Body = bodies[0]
-		} else {
-			ae.Body = bodies
+
+	switch len(bodies) {
+	case 0:
+		ae.Body = map[string]interface{}{
+			"code":    status,
+			"message": http.StatusText(status),
 		}
+	case 1:
+		ae.Body = bodies[0]
+	default:
+		ae.Body = bodies
 	}
+
 	return ae
 }
 


### PR DESCRIPTION
- apierrorを利用した際にエラーログが出力されていなかった問題の修正
- apierrorのbodyが空だった際に何もbodyが出力されていなかったため `{"code": 400, "message": "Bad Request"}` のようなボディを自動で付与