### PR TITLE
Support optional parameter for methods in TS client

### DIFF
--- a/pkg/client/typescript/templates/api.ts.tmpl
+++ b/pkg/client/typescript/templates/api.ts.tmpl
@@ -99,11 +99,39 @@ class {{ $elem.Name }} {
 	}
 {{- 	range $index, $method := $elem.Methods }}
 
+	/** @deprecated */
 	async {{ $method.Name }}(
 		param: {{ $method.RequestType }},
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<{{ $method.ResponseType }}>;
+	async {{ $method.Name }}(
+		param: {{ $method.RequestType }},
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<{{ $method.ResponseType }}>;
+
+	async {{ $method.Name }}(
+		param: {{ $method.RequestType }},
+		arg1?: any,
+		arg2?: any
 	): Promise<{{ $method.ResponseType }}> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -250,11 +278,39 @@ export class APIClient {
 	}
 {{- range $index, $method := .Methods }}
 
+	/** @deprecated */
 	async {{ $method.Name }}(
 		param: {{ $method.RequestType }},
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<{{ $method.ResponseType }}>;
+	async {{ $method.Name }}(
+		param: {{ $method.RequestType }},
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<{{ $method.ResponseType }}>;
+
+	async {{ $method.Name }}(
+		param: {{ $method.RequestType }},
+		arg1?: any,
+		arg2?: any
 	): Promise<{{ $method.ResponseType }}> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {

--- a/pkg/client/typescript/templates/api.ts.tmpl
+++ b/pkg/client/typescript/templates/api.ts.tmpl
@@ -129,7 +129,7 @@ class {{ $elem.Name }} {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
@@ -308,7 +308,7 @@ export class APIClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];

--- a/pkg/client/typescript/testdata/api_client.ts
+++ b/pkg/client/typescript/testdata/api_client.ts
@@ -145,11 +145,39 @@ class ServiceClient {
 		}
 	}
 
+	/** @deprecated */
 	async getArticle(
 		param: ServiceGetArticleRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceGetArticleResponse>;
+	async getArticle(
+		param: ServiceGetArticleRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceGetArticleResponse>;
+
+	async getArticle(
+		param: ServiceGetArticleRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceGetArticleResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -242,11 +270,39 @@ class ServiceStaticPageClient {
 		}
 	}
 
+	/** @deprecated */
 	async getStaticPage(
 		param: ServiceStaticPageGetStaticPageRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceStaticPageGetStaticPageResponse>;
+	async getStaticPage(
+		param: ServiceStaticPageGetStaticPageRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceStaticPageGetStaticPageResponse>;
+
+	async getStaticPage(
+		param: ServiceStaticPageGetStaticPageRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceStaticPageGetStaticPageResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -350,11 +406,39 @@ class ServiceUser2Client {
 		}
 	}
 
+	/** @deprecated */
 	async deleteUser(
 		param: ServiceUser2DeleteUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2DeleteUserResponse>;
+	async deleteUser(
+		param: ServiceUser2DeleteUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2DeleteUserResponse>;
+
+	async deleteUser(
+		param: ServiceUser2DeleteUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2DeleteUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['id', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -402,11 +486,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async getUser(
 		param: ServiceUser2GetUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2GetUserResponse>;
+	async getUser(
+		param: ServiceUser2GetUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2GetUserResponse>;
+
+	async getUser(
+		param: ServiceUser2GetUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2GetUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['id', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -452,11 +564,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserName(
 		param: ServiceUser2PostUpdateUserNameRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2PostUpdateUserNameResponse>;
+	async postUpdateUserName(
+		param: ServiceUser2PostUpdateUserNameRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2PostUpdateUserNameResponse>;
+
+	async postUpdateUserName(
+		param: ServiceUser2PostUpdateUserNameRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2PostUpdateUserNameResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -503,11 +643,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserPassword(
 		param: ServiceUser2PostUpdateUserPasswordRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2PostUpdateUserPasswordResponse>;
+	async postUpdateUserPassword(
+		param: ServiceUser2PostUpdateUserPasswordRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2PostUpdateUserPasswordResponse>;
+
+	async postUpdateUserPassword(
+		param: ServiceUser2PostUpdateUserPasswordRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2PostUpdateUserPasswordResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -612,11 +780,39 @@ class ServiceUser2UserIDClient {
 		}
 	}
 
+	/** @deprecated */
 	async getUserJobGet(
 		param: ServiceUser2UserIDGetUserJobGetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2UserIDGetUserJobGetResponse>;
+	async getUserJobGet(
+		param: ServiceUser2UserIDGetUserJobGetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2UserIDGetUserJobGetResponse>;
+
+	async getUserJobGet(
+		param: ServiceUser2UserIDGetUserJobGetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2UserIDGetUserJobGetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['UserID', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -709,11 +905,39 @@ class ServiceUser2UserIDJobIDClient {
 		}
 	}
 
+	/** @deprecated */
 	async putJob(
 		param: ServiceUser2UserIDJobIDPutJobRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2UserIDJobIDPutJobResponse>;
+	async putJob(
+		param: ServiceUser2UserIDJobIDPutJobRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2UserIDJobIDPutJobResponse>;
+
+	async putJob(
+		param: ServiceUser2UserIDJobIDPutJobRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2UserIDJobIDPutJobResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['JobID', 'UserID', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -807,11 +1031,39 @@ class ServiceUserClient {
 		}
 	}
 
+	/** @deprecated */
 	async get(
 		param: ServiceUserGetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserGetResponse>;
+	async get(
+		param: ServiceUserGetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserGetResponse>;
+
+	async get(
+		param: ServiceUserGetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserGetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -858,11 +1110,39 @@ class ServiceUserClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserName(
 		param: ServiceUserPostUpdateUserNameRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserPostUpdateUserNameResponse>;
+	async postUpdateUserName(
+		param: ServiceUserPostUpdateUserNameRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserPostUpdateUserNameResponse>;
+
+	async postUpdateUserName(
+		param: ServiceUserPostUpdateUserNameRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserPostUpdateUserNameResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -909,11 +1189,39 @@ class ServiceUserClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserPassword(
 		param: ServiceUserPostUpdateUserPasswordRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserPostUpdateUserPasswordResponse>;
+	async postUpdateUserPassword(
+		param: ServiceUserPostUpdateUserPasswordRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserPostUpdateUserPasswordResponse>;
+
+	async postUpdateUserPassword(
+		param: ServiceUserPostUpdateUserPasswordRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserPostUpdateUserPasswordResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1041,11 +1349,39 @@ export class APIClient {
 		}
 	}
 
+	/** @deprecated */
 	async get(
 		param: GetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<GetResponse>;
+	async get(
+		param: GetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<GetResponse>;
+
+	async get(
+		param: GetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<GetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1096,11 +1432,39 @@ export class APIClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postCreateTable(
 		param: PostCreateTableRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<PostCreateTableResponse>;
+	async postCreateTable(
+		param: PostCreateTableRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<PostCreateTableResponse>;
+
+	async postCreateTable(
+		param: PostCreateTableRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<PostCreateTableResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1153,11 +1517,39 @@ export class APIClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postCreateUser(
 		param: PostCreateUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<PostCreateUserResponse>;
+	async postCreateUser(
+		param: PostCreateUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<PostCreateUserResponse>;
+
+	async postCreateUser(
+		param: PostCreateUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<PostCreateUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			options = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {

--- a/samples/empty_root/clients/ts/api_client.ts
+++ b/samples/empty_root/clients/ts/api_client.ts
@@ -76,11 +76,39 @@ class FooBarClient {
 		}
 	}
 
+	/** @deprecated */
 	async postUser(
 		param: FooBarPostUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<FooBarPostUserResponse>;
+	async postUser(
+		param: FooBarPostUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<FooBarPostUserResponse>;
+
+	async postUser(
+		param: FooBarPostUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<FooBarPostUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {

--- a/samples/empty_root/clients/ts/api_client.ts
+++ b/samples/empty_root/clients/ts/api_client.ts
@@ -106,7 +106,7 @@ class FooBarClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];

--- a/samples/empty_root/docs/docs.go
+++ b/samples/empty_root/docs/docs.go
@@ -114,5 +114,5 @@ func (s *s) ReadDoc() string {
 }
 
 func init() {
-	swag.Register(swag.Name, &s{})
+	swag.Register("swagger", &s{})
 }

--- a/samples/standard/clients/ts/api_client.ts
+++ b/samples/standard/clients/ts/api_client.ts
@@ -5,12 +5,12 @@
 import {
 	GetStaticPageRequest as ServiceStaticPageGetStaticPageRequest,
 	GetStaticPageResponse as ServiceStaticPageGetStaticPageResponse,
-} from './classes/service/static_page/types';
+} from './classes/service/static_page/types.ts';
 
 import {
 	GetArticleRequest as ServiceGetArticleRequest,
 	GetArticleResponse as ServiceGetArticleResponse,
-} from './classes/service/types';
+} from './classes/service/types.ts';
 
 import {
 	GetRequest as ServiceUserGetRequest,
@@ -19,17 +19,17 @@ import {
 	PostUpdateUserNameResponse as ServiceUserPostUpdateUserNameResponse,
 	PostUpdateUserPasswordRequest as ServiceUserPostUpdateUserPasswordRequest,
 	PostUpdateUserPasswordResponse as ServiceUserPostUpdateUserPasswordResponse,
-} from './classes/service/user/types';
+} from './classes/service/user/types.ts';
 
 import {
 	PutJobRequest as ServiceUser2UserIDJobIDPutJobRequest,
 	PutJobResponse as ServiceUser2UserIDJobIDPutJobResponse,
-} from './classes/service/user2/_userID/_JobID/types';
+} from './classes/service/user2/_userID/_JobID/types.ts';
 
 import {
 	GetUserJobGetRequest as ServiceUser2UserIDGetUserJobGetRequest,
 	GetUserJobGetResponse as ServiceUser2UserIDGetUserJobGetResponse,
-} from './classes/service/user2/_userID/types';
+} from './classes/service/user2/_userID/types.ts';
 
 import {
 	DeleteUserRequest as ServiceUser2DeleteUserRequest,
@@ -40,7 +40,7 @@ import {
 	PostUpdateUserNameResponse as ServiceUser2PostUpdateUserNameResponse,
 	PostUpdateUserPasswordRequest as ServiceUser2PostUpdateUserPasswordRequest,
 	PostUpdateUserPasswordResponse as ServiceUser2PostUpdateUserPasswordResponse,
-} from './classes/service/user2/types';
+} from './classes/service/user2/types.ts';
 
 import {
 	GetRequest as GetRequest,
@@ -49,7 +49,7 @@ import {
 	PostCreateTableResponse as PostCreateTableResponse,
 	PostCreateUserRequest as PostCreateUserRequest,
 	PostCreateUserResponse as PostCreateUserResponse,
-} from './classes/types';
+} from './classes/types.ts';
 
 export interface MiddlewareContext {
 	httpMethod: string;
@@ -175,7 +175,7 @@ class ServiceClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -300,7 +300,7 @@ class ServiceStaticPageClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -436,7 +436,7 @@ class ServiceUser2Client {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = ['id', ];
@@ -516,7 +516,7 @@ class ServiceUser2Client {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = ['id', ];
@@ -594,7 +594,7 @@ class ServiceUser2Client {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -673,7 +673,7 @@ class ServiceUser2Client {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -810,7 +810,7 @@ class ServiceUser2UserIDClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = ['UserID', ];
@@ -935,7 +935,7 @@ class ServiceUser2UserIDJobIDClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = ['JobID', 'UserID', ];
@@ -1061,7 +1061,7 @@ class ServiceUserClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -1140,7 +1140,7 @@ class ServiceUserClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -1219,7 +1219,7 @@ class ServiceUserClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -1379,7 +1379,7 @@ export class APIClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -1462,7 +1462,7 @@ export class APIClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];
@@ -1547,7 +1547,7 @@ export class APIClient {
 			options = arg2;
 		} else {
 			headers = arg1.headers;
-			headers = arg1.options;
+			options = arg1.options;
 		}
 
 	    const excludeParams: string[] = [];

--- a/samples/standard/clients/ts/api_client.ts
+++ b/samples/standard/clients/ts/api_client.ts
@@ -145,11 +145,39 @@ class ServiceClient {
 		}
 	}
 
+	/** @deprecated */
 	async getArticle(
 		param: ServiceGetArticleRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceGetArticleResponse>;
+	async getArticle(
+		param: ServiceGetArticleRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceGetArticleResponse>;
+
+	async getArticle(
+		param: ServiceGetArticleRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceGetArticleResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -242,11 +270,39 @@ class ServiceStaticPageClient {
 		}
 	}
 
+	/** @deprecated */
 	async getStaticPage(
 		param: ServiceStaticPageGetStaticPageRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceStaticPageGetStaticPageResponse>;
+	async getStaticPage(
+		param: ServiceStaticPageGetStaticPageRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceStaticPageGetStaticPageResponse>;
+
+	async getStaticPage(
+		param: ServiceStaticPageGetStaticPageRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceStaticPageGetStaticPageResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -350,11 +406,39 @@ class ServiceUser2Client {
 		}
 	}
 
+	/** @deprecated */
 	async deleteUser(
 		param: ServiceUser2DeleteUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2DeleteUserResponse>;
+	async deleteUser(
+		param: ServiceUser2DeleteUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2DeleteUserResponse>;
+
+	async deleteUser(
+		param: ServiceUser2DeleteUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2DeleteUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['id', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -402,11 +486,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async getUser(
 		param: ServiceUser2GetUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2GetUserResponse>;
+	async getUser(
+		param: ServiceUser2GetUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2GetUserResponse>;
+
+	async getUser(
+		param: ServiceUser2GetUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2GetUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['id', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -452,11 +564,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserName(
 		param: ServiceUser2PostUpdateUserNameRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2PostUpdateUserNameResponse>;
+	async postUpdateUserName(
+		param: ServiceUser2PostUpdateUserNameRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2PostUpdateUserNameResponse>;
+
+	async postUpdateUserName(
+		param: ServiceUser2PostUpdateUserNameRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2PostUpdateUserNameResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -503,11 +643,39 @@ class ServiceUser2Client {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserPassword(
 		param: ServiceUser2PostUpdateUserPasswordRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2PostUpdateUserPasswordResponse>;
+	async postUpdateUserPassword(
+		param: ServiceUser2PostUpdateUserPasswordRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2PostUpdateUserPasswordResponse>;
+
+	async postUpdateUserPassword(
+		param: ServiceUser2PostUpdateUserPasswordRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2PostUpdateUserPasswordResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -612,11 +780,39 @@ class ServiceUser2UserIDClient {
 		}
 	}
 
+	/** @deprecated */
 	async getUserJobGet(
 		param: ServiceUser2UserIDGetUserJobGetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2UserIDGetUserJobGetResponse>;
+	async getUserJobGet(
+		param: ServiceUser2UserIDGetUserJobGetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2UserIDGetUserJobGetResponse>;
+
+	async getUserJobGet(
+		param: ServiceUser2UserIDGetUserJobGetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2UserIDGetUserJobGetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['UserID', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -709,11 +905,39 @@ class ServiceUser2UserIDJobIDClient {
 		}
 	}
 
+	/** @deprecated */
 	async putJob(
 		param: ServiceUser2UserIDJobIDPutJobRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUser2UserIDJobIDPutJobResponse>;
+	async putJob(
+		param: ServiceUser2UserIDJobIDPutJobRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUser2UserIDJobIDPutJobResponse>;
+
+	async putJob(
+		param: ServiceUser2UserIDJobIDPutJobRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUser2UserIDJobIDPutJobResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = ['JobID', 'UserID', ];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -807,11 +1031,39 @@ class ServiceUserClient {
 		}
 	}
 
+	/** @deprecated */
 	async get(
 		param: ServiceUserGetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserGetResponse>;
+	async get(
+		param: ServiceUserGetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserGetResponse>;
+
+	async get(
+		param: ServiceUserGetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserGetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -858,11 +1110,39 @@ class ServiceUserClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserName(
 		param: ServiceUserPostUpdateUserNameRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserPostUpdateUserNameResponse>;
+	async postUpdateUserName(
+		param: ServiceUserPostUpdateUserNameRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserPostUpdateUserNameResponse>;
+
+	async postUpdateUserName(
+		param: ServiceUserPostUpdateUserNameRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserPostUpdateUserNameResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -909,11 +1189,39 @@ class ServiceUserClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postUpdateUserPassword(
 		param: ServiceUserPostUpdateUserPasswordRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<ServiceUserPostUpdateUserPasswordResponse>;
+	async postUpdateUserPassword(
+		param: ServiceUserPostUpdateUserPasswordRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<ServiceUserPostUpdateUserPasswordResponse>;
+
+	async postUpdateUserPassword(
+		param: ServiceUserPostUpdateUserPasswordRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<ServiceUserPostUpdateUserPasswordResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1041,11 +1349,39 @@ export class APIClient {
 		}
 	}
 
+	/** @deprecated */
 	async get(
 		param: GetRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<GetResponse>;
+	async get(
+		param: GetRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<GetResponse>;
+
+	async get(
+		param: GetRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<GetResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1096,11 +1432,39 @@ export class APIClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postCreateTable(
 		param: PostCreateTableRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<PostCreateTableResponse>;
+	async postCreateTable(
+		param: PostCreateTableRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<PostCreateTableResponse>;
+
+	async postCreateTable(
+		param: PostCreateTableRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<PostCreateTableResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {
@@ -1153,11 +1517,39 @@ export class APIClient {
 		return res;
 	}
 
+	/** @deprecated */
 	async postCreateUser(
 		param: PostCreateUserRequest,
 		headers?: {[key: string]: string},
 		options?: {[key: string]: any}
+	): Promise<PostCreateUserResponse>;
+	async postCreateUser(
+		param: PostCreateUserRequest,
+		options?: {
+			headers?: {[key: string]: string},
+			options?: {[key: string]: any}
+		}
+	): Promise<PostCreateUserResponse>;
+
+	async postCreateUser(
+		param: PostCreateUserRequest,
+		arg1?: any,
+		arg2?: any
 	): Promise<PostCreateUserResponse> {
+		let headers: {[key: string]: string} | undefined;
+		let options: {[key: string]: any} | undefined;
+
+		if (
+			arg2 !== undefined || arg1 === undefined ||
+			Object.values(arg1).filter(v => typeof v !== 'string').length === 0
+		) {
+			headers = arg1;
+			options = arg2;
+		} else {
+			headers = arg1.headers;
+			headers = arg1.options;
+		}
+
 	    const excludeParams: string[] = [];
 	    let mockHeaders: {[key: string]: string} = {};
 	    if (options && options['mock_option']) {

--- a/samples/standard/clients/ts/api_client.ts
+++ b/samples/standard/clients/ts/api_client.ts
@@ -5,12 +5,12 @@
 import {
 	GetStaticPageRequest as ServiceStaticPageGetStaticPageRequest,
 	GetStaticPageResponse as ServiceStaticPageGetStaticPageResponse,
-} from './classes/service/static_page/types.ts';
+} from './classes/service/static_page/types';
 
 import {
 	GetArticleRequest as ServiceGetArticleRequest,
 	GetArticleResponse as ServiceGetArticleResponse,
-} from './classes/service/types.ts';
+} from './classes/service/types';
 
 import {
 	GetRequest as ServiceUserGetRequest,
@@ -19,17 +19,17 @@ import {
 	PostUpdateUserNameResponse as ServiceUserPostUpdateUserNameResponse,
 	PostUpdateUserPasswordRequest as ServiceUserPostUpdateUserPasswordRequest,
 	PostUpdateUserPasswordResponse as ServiceUserPostUpdateUserPasswordResponse,
-} from './classes/service/user/types.ts';
+} from './classes/service/user/types';
 
 import {
 	PutJobRequest as ServiceUser2UserIDJobIDPutJobRequest,
 	PutJobResponse as ServiceUser2UserIDJobIDPutJobResponse,
-} from './classes/service/user2/_userID/_JobID/types.ts';
+} from './classes/service/user2/_userID/_JobID/types';
 
 import {
 	GetUserJobGetRequest as ServiceUser2UserIDGetUserJobGetRequest,
 	GetUserJobGetResponse as ServiceUser2UserIDGetUserJobGetResponse,
-} from './classes/service/user2/_userID/types.ts';
+} from './classes/service/user2/_userID/types';
 
 import {
 	DeleteUserRequest as ServiceUser2DeleteUserRequest,
@@ -40,7 +40,7 @@ import {
 	PostUpdateUserNameResponse as ServiceUser2PostUpdateUserNameResponse,
 	PostUpdateUserPasswordRequest as ServiceUser2PostUpdateUserPasswordRequest,
 	PostUpdateUserPasswordResponse as ServiceUser2PostUpdateUserPasswordResponse,
-} from './classes/service/user2/types.ts';
+} from './classes/service/user2/types';
 
 import {
 	GetRequest as GetRequest,
@@ -49,7 +49,7 @@ import {
 	PostCreateTableResponse as PostCreateTableResponse,
 	PostCreateUserRequest as PostCreateUserRequest,
 	PostCreateUserResponse as PostCreateUserResponse,
-} from './classes/types.ts';
+} from './classes/types';
 
 export interface MiddlewareContext {
 	httpMethod: string;

--- a/samples/standard/docs/docs.go
+++ b/samples/standard/docs/docs.go
@@ -795,5 +795,5 @@ func (s *s) ReadDoc() string {
 }
 
 func init() {
-	swag.Register(swag.Name, &s{})
+	swag.Register("swagger", &s{})
 }


### PR DESCRIPTION
Closes #212

```typescript
// deprecated, but still available
await client.get({
    Enum: 'A',
    Param: 'A',
    Time: 'A',
}, {
    aaa: 'aaa',
})

// newly recommended/available way
await client.get({
    Enum: 'A',
    Param: 'A',
    Time: 'A',
}, {
    headers: {
        aaa: 'aaa',
    }
})
```