### PR TITLE
Remove installation for unused commandd, Update golangci-lint, Specify swag version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,9 @@ init: bootstrap
 
 .PHONY: bootstrap
 bootstrap:
-	(cd $(mktemp -d); GO111MODULE=on \
-			go get \
-			github.com/golang/mock/gomock \
-			github.com/golang/mock/mockgen \
-			github.com/golang/protobuf/protoc-gen-go \
-			github.com/favadi/protoc-go-inject-tag \
-			github.com/moznion/go-errgen/cmd/errgen \
-	)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.24.0
-	GOBIN=${PWD}/bin go install github.com/swaggo/swag/cmd/swag@latest
+	# Installed in ./bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
+	GOBIN=${PWD}/bin go install github.com/swaggo/swag/cmd/swag@v1.7.4
 
 .PHONY: test
 test:

--- a/samples/empty_root/docs/docs.go
+++ b/samples/empty_root/docs/docs.go
@@ -114,5 +114,5 @@ func (s *s) ReadDoc() string {
 }
 
 func init() {
-	swag.Register(swag.Name, &s{})
+	swag.Register("swagger", &s{})
 }

--- a/samples/standard/docs/docs.go
+++ b/samples/standard/docs/docs.go
@@ -795,5 +795,5 @@ func (s *s) ReadDoc() string {
 }
 
 func init() {
-	swag.Register(swag.Name, &s{})
+	swag.Register("swagger", &s{})
 }


### PR DESCRIPTION
- 利用してないコマンド群のインストールを削除
- golangci-lintを(M1バイナリが配布されている)最新のバージョンにアップデート
- swagを最新にし、バージョンを固定