### PR TITLE
Update go-dartfmt to v0.1.0 to fix a bug in dart formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 )
 
 require (
-	github.com/go-generalize/go-dartfmt v0.0.0-20220107102326-9bd233e600eb
+	github.com/go-generalize/go-dartfmt v0.1.0
 	github.com/go-generalize/go-easyparser v0.2.0
 	github.com/go-generalize/go2dart v0.4.6
 	github.com/swaggo/swag v1.7.8

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-generalize/go-dartfmt v0.0.0-20220107102326-9bd233e600eb h1:O27wO2Ie0j/whY+iBYsJkUAyfiGyNNHRZZuB2Xj1Sxo=
 github.com/go-generalize/go-dartfmt v0.0.0-20220107102326-9bd233e600eb/go.mod h1:xbPNNnCJpX/CtvxIy1grvi9X2A57jC6fsvoYVDXpAWQ=
+github.com/go-generalize/go-dartfmt v0.1.0 h1:NBqckiza6O7zatNglm5Ry8P26mIxiHB26cGAIVUGdjI=
+github.com/go-generalize/go-dartfmt v0.1.0/go.mod h1:xbPNNnCJpX/CtvxIy1grvi9X2A57jC6fsvoYVDXpAWQ=
 github.com/go-generalize/go-easyparser v0.2.0 h1:BAkuf9qkgIX1rm2nMVT3HiXO787Tnja2ZTtuNbuxvPk=
 github.com/go-generalize/go-easyparser v0.2.0/go.mod h1:I+Ifnjzw7UNzxkENknQQY9yB2gsz9RekzAbKLYq/Dzw=
 github.com/go-generalize/go2dart v0.4.6 h1:YarRucKM1thDBXcf8OJjOtferGzlFaqo0QUNo6oE7Sk=


### PR DESCRIPTION
Fix #254 
flutter formatも利用可能なようにしていたが、それが悪さをしていたので削除して `dart format` か `dartfmt` だけに絞った

Related to https://github.com/go-generalize/go-dartfmt/pull/1