### PR TITLE
Remove warnings in dart client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 require (
 	github.com/go-generalize/go-dartfmt v0.0.0-20220107102326-9bd233e600eb
 	github.com/go-generalize/go-easyparser v0.2.0
-	github.com/go-generalize/go2dart v0.4.6
+	github.com/go-generalize/go2dart v0.4.7
 	github.com/swaggo/swag v1.7.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/go-generalize/go-easyparser v0.2.0 h1:BAkuf9qkgIX1rm2nMVT3HiXO787Tnja
 github.com/go-generalize/go-easyparser v0.2.0/go.mod h1:I+Ifnjzw7UNzxkENknQQY9yB2gsz9RekzAbKLYq/Dzw=
 github.com/go-generalize/go2dart v0.4.6 h1:YarRucKM1thDBXcf8OJjOtferGzlFaqo0QUNo6oE7Sk=
 github.com/go-generalize/go2dart v0.4.6/go.mod h1:qCKIC028FFZnNDSjs3brBSuC6VoiRACdpO2erlYVg0k=
+github.com/go-generalize/go2dart v0.4.7 h1:vBSSVrQRzHWs5KFzw6LwWDT5p/ZRzLumz+S40d9ijI0=
+github.com/go-generalize/go2dart v0.4.7/go.mod h1:qCKIC028FFZnNDSjs3brBSuC6VoiRACdpO2erlYVg0k=
 github.com/go-generalize/go2go v0.0.0-20210311170338-9701de42e3ad h1:9oYY/ZcAf3VVRhxaxolqoTVprrx9A7N8INWAfWCRwBc=
 github.com/go-generalize/go2go v0.0.0-20210311170338-9701de42e3ad/go.mod h1:YCmZm0ss4r71rT/Q6AgK4vre4tSFfJ1W/eDHWsmnLCc=
 github.com/go-generalize/go2ts v1.0.5-0.20210311100632-95c274e947f1/go.mod h1:075q+zcpc6IjwYy9WpJpY+M9ssbEA6uccjzWwr59t3M=

--- a/pkg/client/dart/generator.go
+++ b/pkg/client/dart/generator.go
@@ -142,8 +142,10 @@ func (g *generator) generateGroup(gr *parser.Group) childrenType {
 		client.Children = append(client.Children, g.generateGroup(child))
 	}
 
-	// Update global variables
-	g.Imports = append(g.Imports, it)
+	if len(client.Methods) != 0 {
+		// Update global variables
+		g.Imports = append(g.Imports, it)
+	}
 
 	if gr.GetParent() == nil {
 		g.clientType = client

--- a/pkg/client/dart/templates/api.dart
+++ b/pkg/client/dart/templates/api.dart
@@ -22,15 +22,15 @@ class {{ $elem.Name }} {
     this.baseURL,
     this.headers,
     this.client,
-  ) {
+  ){{ if .Children }} {
 {{- 	range $index, $elem := .Children }}
-    this.{{ $elem.Name }} = {{ $elem.ClassName }}(
-			this.baseURL,
-			this.headers,
-			this.client,
+    {{ $elem.Name }} = {{ $elem.ClassName }}(
+			baseURL,
+			headers,
+			client,
 		);
 {{- 	end }}
-  }
+  }{{ else }};{{ end }}
 
   Map<String, dynamic> getRequestObject(Map<String, dynamic> obj, List<String> routingPath) {
     final copied = {...obj};
@@ -52,7 +52,7 @@ class {{ $elem.Name }} {
   ) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
+    final excludeParams = <String>[{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -128,8 +128,8 @@ class APIClient {
     this.headers['Content-Type'] = 'application/json';
 {{- 	range $index, $elem := .Children }}
 
-		this.{{ $elem.Name }} = {{ $elem.ClassName }}(
-			this.baseURL,
+		{{ $elem.Name }} = {{ $elem.ClassName }}(
+			baseURL,
 			this.headers,
 			this.client,
 		);
@@ -156,7 +156,7 @@ class APIClient {
   ) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
+    final excludeParams = <String>[{{ range $param := $method.URLParams }}'{{ $param }}', {{ end }}];
 
     headers = {...this.headers, ...headers ?? {}};
 

--- a/samples/empty_root/clients/dart/api_client.dart
+++ b/samples/empty_root/clients/dart/api_client.dart
@@ -4,8 +4,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import './classes/foo/bar/types.dart' as types__foo_bar;
-import './classes/foo/types.dart' as types__foo;
-import './classes/types.dart' as types_;
 
 class FooBarClient {
   Map<String, String> headers = {};
@@ -16,7 +14,7 @@ class FooBarClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -34,7 +32,7 @@ class FooBarClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -69,10 +67,10 @@ class FooClient {
     this.headers,
     this.client,
   ) {
-    this.bar = FooBarClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    bar = FooBarClient(
+      baseURL,
+      headers,
+      client,
     );
   }
 
@@ -111,8 +109,8 @@ class APIClient {
 
     this.headers['Content-Type'] = 'application/json';
 
-    this.foo = FooClient(
-      this.baseURL,
+    foo = FooClient(
+      baseURL,
       this.headers,
       this.client,
     );

--- a/samples/empty_root/clients/dart/classes/foo/bar/types.dart
+++ b/samples/empty_root/clients/dart/classes/foo/bar/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 

--- a/samples/empty_root/clients/dart/classes/foo/types.dart
+++ b/samples/empty_root/clients/dart/classes/foo/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 

--- a/samples/empty_root/clients/dart/classes/types.dart
+++ b/samples/empty_root/clients/dart/classes/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 

--- a/samples/standard/clients/dart/api_client.dart
+++ b/samples/standard/clients/dart/api_client.dart
@@ -3,11 +3,8 @@
 // generated version: (devel)
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import './classes/service/groups/common/types.dart'
-    as types__service_groups_common;
 import './classes/service/groups/types.dart' as types__service_groups;
 import './classes/service/static_page/types.dart' as types__service_static_page;
-import './classes/service/table/types.dart' as types__service_table;
 import './classes/service/types.dart' as types__service;
 import './classes/service/user/types.dart' as types__service_user;
 import './classes/service/user2/_userID/_JobID/types.dart'
@@ -32,30 +29,30 @@ class ServiceClient {
     this.headers,
     this.client,
   ) {
-    this.groups = ServiceGroupsClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    groups = ServiceGroupsClient(
+      baseURL,
+      headers,
+      client,
     );
-    this.static_page = ServiceStaticPageClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    static_page = ServiceStaticPageClient(
+      baseURL,
+      headers,
+      client,
     );
-    this.table = ServiceTableClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    table = ServiceTableClient(
+      baseURL,
+      headers,
+      client,
     );
-    this.user = ServiceUserClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    user = ServiceUserClient(
+      baseURL,
+      headers,
+      client,
     );
-    this.user2 = ServiceUser2Client(
-      this.baseURL,
-      this.headers,
-      this.client,
+    user2 = ServiceUser2Client(
+      baseURL,
+      headers,
+      client,
     );
   }
 
@@ -75,7 +72,7 @@ class ServiceClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -113,10 +110,10 @@ class ServiceGroupsClient {
     this.headers,
     this.client,
   ) {
-    this.common = ServiceGroupsCommonClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    common = ServiceGroupsCommonClient(
+      baseURL,
+      headers,
+      client,
     );
   }
 
@@ -136,7 +133,7 @@ class ServiceGroupsClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -172,7 +169,7 @@ class ServiceGroupsCommonClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -193,7 +190,7 @@ class ServiceStaticPageClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -211,7 +208,7 @@ class ServiceStaticPageClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -247,7 +244,7 @@ class ServiceTableClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -270,10 +267,10 @@ class ServiceUser2Client {
     this.headers,
     this.client,
   ) {
-    this.userID = ServiceUser2UserIDClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    userID = ServiceUser2UserIDClient(
+      baseURL,
+      headers,
+      client,
     );
   }
 
@@ -293,7 +290,7 @@ class ServiceUser2Client {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [
+    final excludeParams = <String>[
       'id',
     ];
 
@@ -326,7 +323,7 @@ class ServiceUser2Client {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [
+    final excludeParams = <String>[
       'id',
     ];
 
@@ -361,7 +358,7 @@ class ServiceUser2Client {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -393,7 +390,7 @@ class ServiceUser2Client {
           Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -429,10 +426,10 @@ class ServiceUser2UserIDClient {
     this.headers,
     this.client,
   ) {
-    this.JobID = ServiceUser2UserIDJobIDClient(
-      this.baseURL,
-      this.headers,
-      this.client,
+    JobID = ServiceUser2UserIDJobIDClient(
+      baseURL,
+      headers,
+      client,
     );
   }
 
@@ -452,7 +449,7 @@ class ServiceUser2UserIDClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [
+    final excludeParams = <String>[
       'UserID',
     ];
 
@@ -490,7 +487,7 @@ class ServiceUser2UserIDJobIDClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -508,7 +505,7 @@ class ServiceUser2UserIDJobIDClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [
+    final excludeParams = <String>[
       'JobID',
       'UserID',
     ];
@@ -546,7 +543,7 @@ class ServiceUserClient {
     this.baseURL,
     this.headers,
     this.client,
-  ) {}
+  );
 
   Map<String, dynamic> getRequestObject(
       Map<String, dynamic> obj, List<String> routingPath) {
@@ -564,7 +561,7 @@ class ServiceUserClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -596,7 +593,7 @@ class ServiceUserClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -628,7 +625,7 @@ class ServiceUserClient {
           Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -678,8 +675,8 @@ class APIClient {
 
     this.headers['Content-Type'] = 'application/json';
 
-    this.service = ServiceClient(
-      this.baseURL,
+    service = ServiceClient(
+      baseURL,
       this.headers,
       this.client,
     );
@@ -700,7 +697,7 @@ class APIClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -732,7 +729,7 @@ class APIClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 
@@ -762,7 +759,7 @@ class APIClient {
       Object? mockOption}) async {
     client = client ?? this.client;
 
-    List<String> excludeParams = [];
+    final excludeParams = <String>[];
 
     headers = {...this.headers, ...headers ?? {}};
 

--- a/samples/standard/clients/dart/classes/service/groups/common/types.dart
+++ b/samples/standard/clients/dart/classes/service/groups/common/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -122,19 +122,19 @@ class Metadata {
 
   factory Metadata.fromJson(Map<String, dynamic> json) {
     return Metadata(
-      createdAt: DateTimeConverter().fromJson(json['CreatedAt']),
-      id: DoNothingConverter<String>().fromJson(json['ID']),
-      name: DoNothingConverter<String>().fromJson(json['Name']),
-      updatedAt: DateTimeConverter().fromJson(json['UpdatedAt']),
+      createdAt: const DateTimeConverter().fromJson(json['CreatedAt']),
+      id: const DoNothingConverter<String>().fromJson(json['ID']),
+      name: const DoNothingConverter<String>().fromJson(json['Name']),
+      updatedAt: const DateTimeConverter().fromJson(json['UpdatedAt']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'CreatedAt': DateTimeConverter().toJson(createdAt),
-      'ID': DoNothingConverter<String>().toJson(id),
-      'Name': DoNothingConverter<String>().toJson(name),
-      'UpdatedAt': DateTimeConverter().toJson(updatedAt),
+      'CreatedAt': const DateTimeConverter().toJson(createdAt),
+      'ID': const DoNothingConverter<String>().toJson(id),
+      'Name': const DoNothingConverter<String>().toJson(name),
+      'UpdatedAt': const DateTimeConverter().toJson(updatedAt),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/groups/types.dart
+++ b/samples/standard/clients/dart/classes/service/groups/types.dart
@@ -25,7 +25,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -117,13 +117,14 @@ class Company {
 
   factory Company.fromJson(Map<String, dynamic> json) {
     return Company(
-      metadata: external_ff6726e.MetadataConverter().fromJson(json['Metadata']),
+      metadata:
+          const external_ff6726e.MetadataConverter().fromJson(json['Metadata']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Metadata': external_ff6726e.MetadataConverter().toJson(metadata),
+      'Metadata': const external_ff6726e.MetadataConverter().toJson(metadata),
     };
   }
 }
@@ -152,13 +153,14 @@ class Department {
 
   factory Department.fromJson(Map<String, dynamic> json) {
     return Department(
-      metadata: external_ff6726e.MetadataConverter().fromJson(json['Metadata']),
+      metadata:
+          const external_ff6726e.MetadataConverter().fromJson(json['Metadata']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Metadata': external_ff6726e.MetadataConverter().toJson(metadata),
+      'Metadata': const external_ff6726e.MetadataConverter().toJson(metadata),
     };
   }
 }
@@ -216,11 +218,13 @@ class GetGroupsResponse {
 
   factory GetGroupsResponse.fromJson(Map<String, dynamic> json) {
     return GetGroupsResponse(
-      companies: NullableConverter<List<Company>, List<Map<String, dynamic>>>(
-              ListConverter<Company, Map<String, dynamic>>(CompanyConverter()))
-          .fromJson(json['Companies']),
+      companies:
+          const NullableConverter<List<Company>, List<Map<String, dynamic>>>(
+                  ListConverter<Company, Map<String, dynamic>>(
+                      CompanyConverter()))
+              .fromJson(json['Companies']),
       departments:
-          NullableConverter<List<Department>, List<Map<String, dynamic>>>(
+          const NullableConverter<List<Department>, List<Map<String, dynamic>>>(
                   ListConverter<Department, Map<String, dynamic>>(
                       DepartmentConverter()))
               .fromJson(json['Departments']),
@@ -229,11 +233,13 @@ class GetGroupsResponse {
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Companies': NullableConverter<List<Company>, List<Map<String, dynamic>>>(
-              ListConverter<Company, Map<String, dynamic>>(CompanyConverter()))
-          .toJson(companies),
+      'Companies':
+          const NullableConverter<List<Company>, List<Map<String, dynamic>>>(
+                  ListConverter<Company, Map<String, dynamic>>(
+                      CompanyConverter()))
+              .toJson(companies),
       'Departments':
-          NullableConverter<List<Department>, List<Map<String, dynamic>>>(
+          const NullableConverter<List<Department>, List<Map<String, dynamic>>>(
                   ListConverter<Department, Map<String, dynamic>>(
                       DepartmentConverter()))
               .toJson(departments),

--- a/samples/standard/clients/dart/classes/service/static_page/types.dart
+++ b/samples/standard/clients/dart/classes/service/static_page/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -145,15 +145,15 @@ class GetStaticPageResponse {
 
   factory GetStaticPageResponse.fromJson(Map<String, dynamic> json) {
     return GetStaticPageResponse(
-      body: DoNothingConverter<String>().fromJson(json['body']),
-      title: DoNothingConverter<String>().fromJson(json['title']),
+      body: const DoNothingConverter<String>().fromJson(json['body']),
+      title: const DoNothingConverter<String>().fromJson(json['title']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'body': DoNothingConverter<String>().toJson(body),
-      'title': DoNothingConverter<String>().toJson(title),
+      'body': const DoNothingConverter<String>().toJson(body),
+      'title': const DoNothingConverter<String>().toJson(title),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/table/types.dart
+++ b/samples/standard/clients/dart/classes/service/table/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -117,15 +117,15 @@ class Pos {
 
   factory Pos.fromJson(Map<String, dynamic> json) {
     return Pos(
-      x: DoNothingConverter<int>().fromJson(json['X']),
-      y: DoNothingConverter<int>().fromJson(json['Y']),
+      x: const DoNothingConverter<int>().fromJson(json['X']),
+      y: const DoNothingConverter<int>().fromJson(json['Y']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'X': DoNothingConverter<int>().toJson(x),
-      'Y': DoNothingConverter<int>().toJson(y),
+      'X': const DoNothingConverter<int>().toJson(x),
+      'Y': const DoNothingConverter<int>().toJson(y),
     };
   }
 }
@@ -153,13 +153,13 @@ class Table {
 
   factory Table.fromJson(Map<String, dynamic> json) {
     return Table(
-      pos: PosConverter().fromJson(json['Pos']),
+      pos: const PosConverter().fromJson(json['Pos']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Pos': PosConverter().toJson(pos),
+      'Pos': const PosConverter().toJson(pos),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/types.dart
+++ b/samples/standard/clients/dart/classes/service/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -116,13 +116,13 @@ class GetArticleRequest {
 
   factory GetArticleRequest.fromJson(Map<String, dynamic> json) {
     return GetArticleRequest(
-      id: DoNothingConverter<int>().fromJson(json['ID']),
+      id: const DoNothingConverter<int>().fromJson(json['ID']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'ID': DoNothingConverter<int>().toJson(id),
+      'ID': const DoNothingConverter<int>().toJson(id),
     };
   }
 }
@@ -157,23 +157,23 @@ class GetArticleResponse {
 
   factory GetArticleResponse.fromJson(Map<String, dynamic> json) {
     return GetArticleResponse(
-      body: DoNothingConverter<String>().fromJson(json['Body']),
-      group: NullableConverter<List<String>, List<String>>(
+      body: const DoNothingConverter<String>().fromJson(json['Body']),
+      group: const NullableConverter<List<String>, List<String>>(
               ListConverter<String, String>(DoNothingConverter<String>()))
           .fromJson(json['Group']),
-      id: DoNothingConverter<int>().fromJson(json['ID']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
+      id: const DoNothingConverter<int>().fromJson(json['ID']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Body': DoNothingConverter<String>().toJson(body),
-      'Group': NullableConverter<List<String>, List<String>>(
+      'Body': const DoNothingConverter<String>().toJson(body),
+      'Group': const NullableConverter<List<String>, List<String>>(
               ListConverter<String, String>(DoNothingConverter<String>()))
           .toJson(group),
-      'ID': DoNothingConverter<int>().toJson(id),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
+      'ID': const DoNothingConverter<int>().toJson(id),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/user/types.dart
+++ b/samples/standard/clients/dart/classes/service/user/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -170,13 +170,13 @@ class PostUpdateUserNameRequest {
 
   factory PostUpdateUserNameRequest.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserNameRequest(
-      name: DoNothingConverter<String>().fromJson(json['Name']),
+      name: const DoNothingConverter<String>().fromJson(json['Name']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Name': DoNothingConverter<String>().toJson(name),
+      'Name': const DoNothingConverter<String>().toJson(name),
     };
   }
 }
@@ -209,17 +209,17 @@ class PostUpdateUserNameResponse {
 
   factory PostUpdateUserNameResponse.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserNameResponse(
-      message: DoNothingConverter<String>().fromJson(json['Message']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
-      status: DoNothingConverter<bool>().fromJson(json['Status']),
+      message: const DoNothingConverter<String>().fromJson(json['Message']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
+      status: const DoNothingConverter<bool>().fromJson(json['Status']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Message': DoNothingConverter<String>().toJson(message),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'Status': DoNothingConverter<bool>().toJson(status),
+      'Message': const DoNothingConverter<String>().toJson(message),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'Status': const DoNothingConverter<bool>().toJson(status),
     };
   }
 }
@@ -251,16 +251,17 @@ class PostUpdateUserPasswordRequest {
 
   factory PostUpdateUserPasswordRequest.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserPasswordRequest(
-      password: DoNothingConverter<String>().fromJson(json['Password']),
+      password: const DoNothingConverter<String>().fromJson(json['Password']),
       passwordConfirm:
-          DoNothingConverter<String>().fromJson(json['PasswordConfirm']),
+          const DoNothingConverter<String>().fromJson(json['PasswordConfirm']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Password': DoNothingConverter<String>().toJson(password),
-      'PasswordConfirm': DoNothingConverter<String>().toJson(passwordConfirm),
+      'Password': const DoNothingConverter<String>().toJson(password),
+      'PasswordConfirm':
+          const DoNothingConverter<String>().toJson(passwordConfirm),
     };
   }
 }
@@ -295,17 +296,17 @@ class PostUpdateUserPasswordResponse {
 
   factory PostUpdateUserPasswordResponse.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserPasswordResponse(
-      message: DoNothingConverter<String>().fromJson(json['Message']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
-      status: DoNothingConverter<bool>().fromJson(json['Status']),
+      message: const DoNothingConverter<String>().fromJson(json['Message']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
+      status: const DoNothingConverter<bool>().fromJson(json['Status']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Message': DoNothingConverter<String>().toJson(message),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'Status': DoNothingConverter<bool>().toJson(status),
+      'Message': const DoNothingConverter<String>().toJson(message),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'Status': const DoNothingConverter<bool>().toJson(status),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/user2/_userID/_JobID/types.dart
+++ b/samples/standard/clients/dart/classes/service/user2/_userID/_JobID/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -118,15 +118,15 @@ class PutJobRequest {
 
   factory PutJobRequest.fromJson(Map<String, dynamic> json) {
     return PutJobRequest(
-      jobID: DoNothingConverter<String>().fromJson(json['JobID']),
-      userID: DoNothingConverter<String>().fromJson(json['UserID']),
+      jobID: const DoNothingConverter<String>().fromJson(json['JobID']),
+      userID: const DoNothingConverter<String>().fromJson(json['UserID']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'JobID': DoNothingConverter<String>().toJson(jobID),
-      'UserID': DoNothingConverter<String>().toJson(userID),
+      'JobID': const DoNothingConverter<String>().toJson(jobID),
+      'UserID': const DoNothingConverter<String>().toJson(userID),
     };
   }
 }
@@ -159,17 +159,17 @@ class PutJobResponse {
 
   factory PutJobResponse.fromJson(Map<String, dynamic> json) {
     return PutJobResponse(
-      jobID: DoNothingConverter<String>().fromJson(json['JobID']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
-      userID: DoNothingConverter<String>().fromJson(json['UserID']),
+      jobID: const DoNothingConverter<String>().fromJson(json['JobID']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
+      userID: const DoNothingConverter<String>().fromJson(json['UserID']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'JobID': DoNothingConverter<String>().toJson(jobID),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'UserID': DoNothingConverter<String>().toJson(userID),
+      'JobID': const DoNothingConverter<String>().toJson(jobID),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'UserID': const DoNothingConverter<String>().toJson(userID),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/user2/_userID/types.dart
+++ b/samples/standard/clients/dart/classes/service/user2/_userID/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -116,13 +116,13 @@ class GetUserJobGetRequest {
 
   factory GetUserJobGetRequest.fromJson(Map<String, dynamic> json) {
     return GetUserJobGetRequest(
-      userID: DoNothingConverter<String>().fromJson(json['UserID']),
+      userID: const DoNothingConverter<String>().fromJson(json['UserID']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'UserID': DoNothingConverter<String>().toJson(userID),
+      'UserID': const DoNothingConverter<String>().toJson(userID),
     };
   }
 }
@@ -153,15 +153,15 @@ class GetUserJobGetResponse {
 
   factory GetUserJobGetResponse.fromJson(Map<String, dynamic> json) {
     return GetUserJobGetResponse(
-      jobName: DoNothingConverter<String>().fromJson(json['JobName']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
+      jobName: const DoNothingConverter<String>().fromJson(json['JobName']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'JobName': DoNothingConverter<String>().toJson(jobName),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
+      'JobName': const DoNothingConverter<String>().toJson(jobName),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/service/user2/types.dart
+++ b/samples/standard/clients/dart/classes/service/user2/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -116,13 +116,13 @@ class DeleteUserRequest {
 
   factory DeleteUserRequest.fromJson(Map<String, dynamic> json) {
     return DeleteUserRequest(
-      id: DoNothingConverter<String>().fromJson(json['id']),
+      id: const DoNothingConverter<String>().fromJson(json['id']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'id': DoNothingConverter<String>().toJson(id),
+      'id': const DoNothingConverter<String>().toJson(id),
     };
   }
 }
@@ -178,13 +178,13 @@ class Embedding {
 
   factory Embedding.fromJson(Map<String, dynamic> json) {
     return Embedding(
-      page: DoNothingConverter<String>().fromJson(json['page']),
+      page: const DoNothingConverter<String>().fromJson(json['page']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'page': DoNothingConverter<String>().toJson(page),
+      'page': const DoNothingConverter<String>().toJson(page),
     };
   }
 }
@@ -217,18 +217,19 @@ class GetUserRequest {
 
   factory GetUserRequest.fromJson(Map<String, dynamic> json) {
     return GetUserRequest(
-      id: DoNothingConverter<String>().fromJson(json['id']),
-      page: DoNothingConverter<String>().fromJson(json['page']),
+      id: const DoNothingConverter<String>().fromJson(json['id']),
+      page: const DoNothingConverter<String>().fromJson(json['page']),
       searchRequest:
-          DoNothingConverter<String>().fromJson(json['search_request']),
+          const DoNothingConverter<String>().fromJson(json['search_request']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'id': DoNothingConverter<String>().toJson(id),
-      'page': DoNothingConverter<String>().toJson(page),
-      'search_request': DoNothingConverter<String>().toJson(searchRequest),
+      'id': const DoNothingConverter<String>().toJson(id),
+      'page': const DoNothingConverter<String>().toJson(page),
+      'search_request':
+          const DoNothingConverter<String>().toJson(searchRequest),
     };
   }
 }
@@ -261,18 +262,18 @@ class GetUserResponse {
 
   factory GetUserResponse.fromJson(Map<String, dynamic> json) {
     return GetUserResponse(
-      id: DoNothingConverter<String>().fromJson(json['ID']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
+      id: const DoNothingConverter<String>().fromJson(json['ID']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
       searchRequest:
-          DoNothingConverter<String>().fromJson(json['SearchRequest']),
+          const DoNothingConverter<String>().fromJson(json['SearchRequest']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'ID': DoNothingConverter<String>().toJson(id),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'SearchRequest': DoNothingConverter<String>().toJson(searchRequest),
+      'ID': const DoNothingConverter<String>().toJson(id),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'SearchRequest': const DoNothingConverter<String>().toJson(searchRequest),
     };
   }
 }
@@ -301,13 +302,13 @@ class PostUpdateUserNameRequest {
 
   factory PostUpdateUserNameRequest.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserNameRequest(
-      name: DoNothingConverter<String>().fromJson(json['Name']),
+      name: const DoNothingConverter<String>().fromJson(json['Name']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Name': DoNothingConverter<String>().toJson(name),
+      'Name': const DoNothingConverter<String>().toJson(name),
     };
   }
 }
@@ -340,17 +341,17 @@ class PostUpdateUserNameResponse {
 
   factory PostUpdateUserNameResponse.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserNameResponse(
-      message: DoNothingConverter<String>().fromJson(json['Message']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
-      status: DoNothingConverter<bool>().fromJson(json['Status']),
+      message: const DoNothingConverter<String>().fromJson(json['Message']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
+      status: const DoNothingConverter<bool>().fromJson(json['Status']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Message': DoNothingConverter<String>().toJson(message),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'Status': DoNothingConverter<bool>().toJson(status),
+      'Message': const DoNothingConverter<String>().toJson(message),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'Status': const DoNothingConverter<bool>().toJson(status),
     };
   }
 }
@@ -382,16 +383,17 @@ class PostUpdateUserPasswordRequest {
 
   factory PostUpdateUserPasswordRequest.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserPasswordRequest(
-      password: DoNothingConverter<String>().fromJson(json['Password']),
+      password: const DoNothingConverter<String>().fromJson(json['Password']),
       passwordConfirm:
-          DoNothingConverter<String>().fromJson(json['PasswordConfirm']),
+          const DoNothingConverter<String>().fromJson(json['PasswordConfirm']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Password': DoNothingConverter<String>().toJson(password),
-      'PasswordConfirm': DoNothingConverter<String>().toJson(passwordConfirm),
+      'Password': const DoNothingConverter<String>().toJson(password),
+      'PasswordConfirm':
+          const DoNothingConverter<String>().toJson(passwordConfirm),
     };
   }
 }
@@ -426,17 +428,17 @@ class PostUpdateUserPasswordResponse {
 
   factory PostUpdateUserPasswordResponse.fromJson(Map<String, dynamic> json) {
     return PostUpdateUserPasswordResponse(
-      message: DoNothingConverter<String>().fromJson(json['Message']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
-      status: DoNothingConverter<bool>().fromJson(json['Status']),
+      message: const DoNothingConverter<String>().fromJson(json['Message']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
+      status: const DoNothingConverter<bool>().fromJson(json['Status']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Message': DoNothingConverter<String>().toJson(message),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
-      'Status': DoNothingConverter<bool>().toJson(status),
+      'Message': const DoNothingConverter<String>().toJson(message),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
+      'Status': const DoNothingConverter<bool>().toJson(status),
     };
   }
 }

--- a/samples/standard/clients/dart/classes/types.dart
+++ b/samples/standard/clients/dart/classes/types.dart
@@ -23,7 +23,7 @@ class ListConverter<T, Base> implements JsonConverter<List<T>, List<Base>> {
 
   @override
   List<Base> toJson(List<T> arr) {
-    return arr.map((e) => internalConverter.toJson(e) as Base).toList();
+    return arr.map((e) => internalConverter.toJson(e)).toList();
   }
 }
 
@@ -93,9 +93,9 @@ class DoNothingConverter<T> implements JsonConverter<T, T> {
 }
 
 enum CreatedType {
-  CreatedTypeGuest,
-  CreatedTypeMember,
-  CreatedTypeOwner,
+  createdTypeGuest,
+  createdTypeMember,
+  createdTypeOwner,
 }
 
 class CreatedTypeConverter implements JsonConverter<CreatedType, int> {
@@ -114,14 +114,14 @@ class CreatedTypeConverter implements JsonConverter<CreatedType, int> {
 
 extension CreatedTypeExtension on CreatedType {
   static final enumToValue = {
-    CreatedType.CreatedTypeGuest: 2,
-    CreatedType.CreatedTypeMember: 1,
-    CreatedType.CreatedTypeOwner: 0,
+    CreatedType.createdTypeGuest: 2,
+    CreatedType.createdTypeMember: 1,
+    CreatedType.createdTypeOwner: 0,
   };
   static final valueToEnum = {
-    2: CreatedType.CreatedTypeGuest,
-    1: CreatedType.CreatedTypeMember,
-    0: CreatedType.CreatedTypeOwner,
+    2: CreatedType.createdTypeGuest,
+    1: CreatedType.createdTypeMember,
+    0: CreatedType.createdTypeOwner,
   };
 
   static CreatedType fromJson(dynamic d) {
@@ -134,9 +134,9 @@ extension CreatedTypeExtension on CreatedType {
 }
 
 enum Enum {
-  EnumA,
-  EnumB,
-  EnumC,
+  enumA,
+  enumB,
+  enumC,
 }
 
 class EnumConverter implements JsonConverter<Enum, String> {
@@ -155,14 +155,14 @@ class EnumConverter implements JsonConverter<Enum, String> {
 
 extension EnumExtension on Enum {
   static final enumToValue = {
-    Enum.EnumA: 'A',
-    Enum.EnumB: 'B',
-    Enum.EnumC: 'C',
+    Enum.enumA: 'A',
+    Enum.enumB: 'B',
+    Enum.enumC: 'C',
   };
   static final valueToEnum = {
-    'A': Enum.EnumA,
-    'B': Enum.EnumB,
-    'C': Enum.EnumC,
+    'A': Enum.enumA,
+    'B': Enum.enumB,
+    'C': Enum.enumC,
   };
 
   static Enum fromJson(dynamic d) {
@@ -195,24 +195,24 @@ class GetRequest {
   DateTime? time;
 
   GetRequest({
-    this.enum_ = Enum.EnumA,
+    this.enum_ = Enum.enumA,
     this.param = '',
     this.time,
   });
 
   factory GetRequest.fromJson(Map<String, dynamic> json) {
     return GetRequest(
-      enum_: EnumConverter().fromJson(json['Enum']),
-      param: DoNothingConverter<String>().fromJson(json['Param']),
-      time: DateTimeConverter().fromJson(json['Time']),
+      enum_: const EnumConverter().fromJson(json['Enum']),
+      param: const DoNothingConverter<String>().fromJson(json['Param']),
+      time: const DateTimeConverter().fromJson(json['Time']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Enum': EnumConverter().toJson(enum_),
-      'Param': DoNothingConverter<String>().toJson(param),
-      'Time': DateTimeConverter().toJson(time),
+      'Enum': const EnumConverter().toJson(enum_),
+      'Param': const DoNothingConverter<String>().toJson(param),
+      'Time': const DateTimeConverter().toJson(time),
     };
   }
 }
@@ -241,13 +241,13 @@ class GetResponse {
 
   factory GetResponse.fromJson(Map<String, dynamic> json) {
     return GetResponse(
-      data: DoNothingConverter<String>().fromJson(json['Data']),
+      data: const DoNothingConverter<String>().fromJson(json['Data']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Data': DoNothingConverter<String>().toJson(data),
+      'Data': const DoNothingConverter<String>().toJson(data),
     };
   }
 }
@@ -282,20 +282,21 @@ class PostCreateTableRequest {
 
   factory PostCreateTableRequest.fromJson(Map<String, dynamic> json) {
     return PostCreateTableRequest(
-      flag: DoNothingConverter<int>().fromJson(json['Flag']),
-      id: DoNothingConverter<String>().fromJson(json['ID']),
-      map: MapConverter<int, int, int>(DoNothingConverter<int>())
+      flag: const DoNothingConverter<int>().fromJson(json['Flag']),
+      id: const DoNothingConverter<String>().fromJson(json['ID']),
+      map: const MapConverter<int, int, int>(DoNothingConverter<int>())
           .fromJson(json['map']),
-      text: DoNothingConverter<String>().fromJson(json['Text']),
+      text: const DoNothingConverter<String>().fromJson(json['Text']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Flag': DoNothingConverter<int>().toJson(flag),
-      'ID': DoNothingConverter<String>().toJson(id),
-      'map': MapConverter<int, int, int>(DoNothingConverter<int>()).toJson(map),
-      'Text': DoNothingConverter<String>().toJson(text),
+      'Flag': const DoNothingConverter<int>().toJson(flag),
+      'ID': const DoNothingConverter<String>().toJson(id),
+      'map': const MapConverter<int, int, int>(DoNothingConverter<int>())
+          .toJson(map),
+      'Text': const DoNothingConverter<String>().toJson(text),
     };
   }
 }
@@ -326,15 +327,15 @@ class PostCreateTableResponse {
 
   factory PostCreateTableResponse.fromJson(Map<String, dynamic> json) {
     return PostCreateTableResponse(
-      id: DoNothingConverter<String>().fromJson(json['ID']),
-      requestTime: DateTimeConverter().fromJson(json['RequestTime']),
+      id: const DoNothingConverter<String>().fromJson(json['ID']),
+      requestTime: const DateTimeConverter().fromJson(json['RequestTime']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'ID': DoNothingConverter<String>().toJson(id),
-      'RequestTime': DateTimeConverter().toJson(requestTime),
+      'ID': const DoNothingConverter<String>().toJson(id),
+      'RequestTime': const DateTimeConverter().toJson(requestTime),
     };
   }
 }
@@ -371,11 +372,11 @@ class PostCreateUserRequest {
 
   factory PostCreateUserRequest.fromJson(Map<String, dynamic> json) {
     return PostCreateUserRequest(
-      birthday: DateTimeConverter().fromJson(json['Birthday']),
-      gender: DoNothingConverter<int>().fromJson(json['Gender']),
-      id: DoNothingConverter<String>().fromJson(json['ID']),
-      password: DoNothingConverter<String>().fromJson(json['Password']),
-      roles: NullableConverter<List<Role?>, List<Map<String, dynamic>?>>(
+      birthday: const DateTimeConverter().fromJson(json['Birthday']),
+      gender: const DoNothingConverter<int>().fromJson(json['Gender']),
+      id: const DoNothingConverter<String>().fromJson(json['ID']),
+      password: const DoNothingConverter<String>().fromJson(json['Password']),
+      roles: const NullableConverter<List<Role?>, List<Map<String, dynamic>?>>(
               ListConverter<Role?, Map<String, dynamic>?>(
                   NullableConverter<Role, Map<String, dynamic>>(
                       RoleConverter())))
@@ -385,15 +386,16 @@ class PostCreateUserRequest {
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Birthday': DateTimeConverter().toJson(birthday),
-      'Gender': DoNothingConverter<int>().toJson(gender),
-      'ID': DoNothingConverter<String>().toJson(id),
-      'Password': DoNothingConverter<String>().toJson(password),
-      'Roles': NullableConverter<List<Role?>, List<Map<String, dynamic>?>>(
-              ListConverter<Role?, Map<String, dynamic>?>(
-                  NullableConverter<Role, Map<String, dynamic>>(
-                      RoleConverter())))
-          .toJson(roles),
+      'Birthday': const DateTimeConverter().toJson(birthday),
+      'Gender': const DoNothingConverter<int>().toJson(gender),
+      'ID': const DoNothingConverter<String>().toJson(id),
+      'Password': const DoNothingConverter<String>().toJson(password),
+      'Roles':
+          const NullableConverter<List<Role?>, List<Map<String, dynamic>?>>(
+                  ListConverter<Role?, Map<String, dynamic>?>(
+                      NullableConverter<Role, Map<String, dynamic>>(
+                          RoleConverter())))
+              .toJson(roles),
     };
   }
 }
@@ -420,7 +422,7 @@ class PostCreateUserResponse {
   bool status;
 
   PostCreateUserResponse({
-    this.createdType = CreatedType.CreatedTypeGuest,
+    this.createdType = CreatedType.createdTypeGuest,
     this.message = '',
     this.requestedAt,
     this.status = false,
@@ -428,19 +430,19 @@ class PostCreateUserResponse {
 
   factory PostCreateUserResponse.fromJson(Map<String, dynamic> json) {
     return PostCreateUserResponse(
-      createdType: CreatedTypeConverter().fromJson(json['CreatedType']),
-      message: DoNothingConverter<String>().fromJson(json['Message']),
-      requestedAt: DateTimeConverter().fromJson(json['RequestedAt']),
-      status: DoNothingConverter<bool>().fromJson(json['Status']),
+      createdType: const CreatedTypeConverter().fromJson(json['CreatedType']),
+      message: const DoNothingConverter<String>().fromJson(json['Message']),
+      requestedAt: const DateTimeConverter().fromJson(json['RequestedAt']),
+      status: const DoNothingConverter<bool>().fromJson(json['Status']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'CreatedType': CreatedTypeConverter().toJson(createdType),
-      'Message': DoNothingConverter<String>().toJson(message),
-      'RequestedAt': DateTimeConverter().toJson(requestedAt),
-      'Status': DoNothingConverter<bool>().toJson(status),
+      'CreatedType': const CreatedTypeConverter().toJson(createdType),
+      'Message': const DoNothingConverter<String>().toJson(message),
+      'RequestedAt': const DateTimeConverter().toJson(requestedAt),
+      'Status': const DoNothingConverter<bool>().toJson(status),
     };
   }
 }
@@ -472,20 +474,21 @@ class Role {
 
   factory Role.fromJson(Map<String, dynamic> json) {
     return Role(
-      id: DoNothingConverter<int>().fromJson(json['ID']),
-      name: DoNothingConverter<String>().fromJson(json['Name']),
-      recursionRoles: NullableConverter<List<Role>, List<Map<String, dynamic>>>(
-              ListConverter<Role, Map<String, dynamic>>(RoleConverter()))
-          .fromJson(json['RecursionRoles']),
+      id: const DoNothingConverter<int>().fromJson(json['ID']),
+      name: const DoNothingConverter<String>().fromJson(json['Name']),
+      recursionRoles:
+          const NullableConverter<List<Role>, List<Map<String, dynamic>>>(
+                  ListConverter<Role, Map<String, dynamic>>(RoleConverter()))
+              .fromJson(json['RecursionRoles']),
     );
   }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'ID': DoNothingConverter<int>().toJson(id),
-      'Name': DoNothingConverter<String>().toJson(name),
+      'ID': const DoNothingConverter<int>().toJson(id),
+      'Name': const DoNothingConverter<String>().toJson(name),
       'RecursionRoles':
-          NullableConverter<List<Role>, List<Map<String, dynamic>>>(
+          const NullableConverter<List<Role>, List<Map<String, dynamic>>>(
                   ListConverter<Role, Map<String, dynamic>>(RoleConverter()))
               .toJson(recursionRoles),
     };


### PR DESCRIPTION
Warningを消すためにEnumの命名規則が変わっているがまだdartなら影響は少なそうなので変更を入れました
https://github.com/go-generalize/go2dart/pull/21/files

その他Warningも削除しました
VSCode/Android Studioで一通りのWarningがないことを確認