### PR TITLE
[BREAKING CHANGE]Update map types to nullable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,17 +13,17 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/spf13/cobra v1.3.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/net v0.0.0-20210913180222-943fd674d43e // indirect
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
-	golang.org/x/tools v0.1.7 // indirect
+	golang.org/x/tools v0.1.9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
 
 require (
 	github.com/fatih/structtag v1.2.0
 	github.com/go-generalize/go-dartfmt v0.1.1
-	github.com/go-generalize/go-easyparser v0.2.0
+	github.com/go-generalize/go-easyparser v0.3.0
 	github.com/go-generalize/go2dart v0.5.1
 	github.com/go-utils/echo-multipart-binder v0.2.1
 	github.com/swaggo/swag v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/go-generalize/go-dartfmt v0.1.1 h1:2W+CD7qGCNE/0JLtm394RJBBi/jhtXUcJ+
 github.com/go-generalize/go-dartfmt v0.1.1/go.mod h1:xbPNNnCJpX/CtvxIy1grvi9X2A57jC6fsvoYVDXpAWQ=
 github.com/go-generalize/go-easyparser v0.2.0 h1:BAkuf9qkgIX1rm2nMVT3HiXO787Tnja2ZTtuNbuxvPk=
 github.com/go-generalize/go-easyparser v0.2.0/go.mod h1:I+Ifnjzw7UNzxkENknQQY9yB2gsz9RekzAbKLYq/Dzw=
+github.com/go-generalize/go-easyparser v0.3.0 h1:GpdD2JZcYVqUarLZlx2lkAlNY0gXHUei9dp4v+k/uB8=
+github.com/go-generalize/go-easyparser v0.3.0/go.mod h1:F7t+z08MQrqBiJY4ht9hkrUFQC+LSt/G6AzfaMX18KY=
 github.com/go-generalize/go2dart v0.5.1 h1:eeSjP7GMArcPHZ+sMYQxU79MxjHDqaQvLcNHdV0erFI=
 github.com/go-generalize/go2dart v0.5.1/go.mod h1:peqHvoBnlWmpJPoYaIyGBditWFaNZ6jR0ywbIRNdY8o=
 github.com/go-generalize/go2go v0.1.0 h1:BqCWA5ifMkEsvKTxcMuiSfu5zuMPg1j2eQVOhz2ievY=
@@ -532,6 +534,8 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e h1:+b/22bPvDYt4NPDcy4xAGCmON713ONAWFeY3Z7I3tR8=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -704,6 +708,8 @@ golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7 h1:6j8CgantCy3yc8JGBqkDLMKWqZ0RDU2g1HVgacojGWQ=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
+golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/client/typescript/testdata/classes/types.ts
+++ b/pkg/client/typescript/testdata/classes/types.ts
@@ -16,7 +16,7 @@ export type PostCreateTableRequest = {
 	Flag: number;
 	ID: string;
 	Text: string;
-	map: {[key: number]: number};
+	map: {[key: number]: number} | null;
 }
 export type PostCreateTableResponse = {
 	ID: string;

--- a/pkg/parser/multipart.go
+++ b/pkg/parser/multipart.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	go2tstypes "github.com/go-generalize/go2ts/pkg/types"
+	eptypes "github.com/go-generalize/go-easyparser/types"
 	"golang.org/x/xerrors"
 )
 
@@ -16,10 +16,10 @@ const FormTagKey = "form"
 
 //MultipartHeader is mime/multipart.FileHeader
 type MultipartHeader struct {
-	go2tstypes.Common
+	eptypes.Common
 }
 
-var _ go2tstypes.Type = &MultipartHeader{}
+var _ eptypes.Type = &MultipartHeader{}
 
 // UsedAsMapKey returns whether this type can be used as the key for map
 func (uf *MultipartHeader) UsedAsMapKey() bool {
@@ -34,13 +34,13 @@ func (uf *MultipartHeader) String() string {
 // FileField is a result type for GetFileFields
 type FileField struct {
 	Key     string
-	Value   go2tstypes.ObjectEntry
+	Value   eptypes.ObjectEntry
 	FormTag string
 	Type    MultipartUploadType
 }
 
 // GetFileFields returns fields for files
-func GetFileFields(obj *go2tstypes.Object) (res []FileField, err error) {
+func GetFileFields(obj *eptypes.Object) (res []FileField, err error) {
 	res = make([]FileField, 0)
 
 	for k, v := range obj.Entries {
@@ -71,7 +71,7 @@ func GetFileFields(obj *go2tstypes.Object) (res []FileField, err error) {
 
 // hasMultipartUpload checks t has *multipart.FileHeader or []*multipart.FileHeader
 // Multipart data in map are not supported
-func hasMultipartUpload(t *go2tstypes.Object) (bool, error) {
+func hasMultipartUpload(t *eptypes.Object) (bool, error) {
 	found := false
 	for _, v := range t.Entries {
 		res, err := ValidateMultipartUploadType(v.Type, v.RawTag)
@@ -99,7 +99,7 @@ const (
 
 // ValidateMultipartUploadType checks t is *multipart.FileHeader or []*multipart.FileHeader
 // And validate form tag
-func ValidateMultipartUploadType(t go2tstypes.Type, tag string) (MultipartUploadType, error) {
+func ValidateMultipartUploadType(t eptypes.Type, tag string) (MultipartUploadType, error) {
 	ut := GetMultipartUploadType(t)
 
 	if ut == UploadNone {
@@ -115,16 +115,16 @@ func ValidateMultipartUploadType(t go2tstypes.Type, tag string) (MultipartUpload
 
 // GetMultipartUploadType checks t is *multipart.FileHeader or []*multipart.FileHeader
 // Multipart data in map are not supported
-func GetMultipartUploadType(t go2tstypes.Type) MultipartUploadType {
-	nullable, ok := t.(*go2tstypes.Nullable)
+func GetMultipartUploadType(t eptypes.Type) MultipartUploadType {
+	nullable, ok := t.(*eptypes.Nullable)
 
 	if !ok {
 		return UploadNone
 	}
 
 	switch t := nullable.Inner.(type) {
-	case *go2tstypes.Array:
-		_, ok := t.Inner.(*go2tstypes.Nullable)
+	case *eptypes.Array:
+		_, ok := t.Inner.(*eptypes.Nullable)
 
 		if !ok {
 			return UploadNone
@@ -144,7 +144,7 @@ func GetMultipartUploadType(t go2tstypes.Type) MultipartUploadType {
 	return UploadNone
 }
 
-func replacer(t types.Type) go2tstypes.Type {
+func replacer(t types.Type) eptypes.Type {
 	named, ok := t.(*types.Named)
 
 	if !ok {

--- a/pkg/parser/types.go
+++ b/pkg/parser/types.go
@@ -6,7 +6,7 @@ import (
 	"go/token"
 	"strings"
 
-	go2tstypes "github.com/go-generalize/go2ts/pkg/types"
+	eptypes "github.com/go-generalize/go-easyparser/types"
 )
 
 // MethodType represents methods for HTTP
@@ -67,8 +67,8 @@ type Endpoint struct {
 	ResponsePayloadName  string
 	RequestPayload       *ast.StructType
 	ResponsePayload      *ast.StructType
-	RequestGo2tsPayload  *go2tstypes.Object
-	ResponseGo2tsPayload *go2tstypes.Object
+	RequestGo2tsPayload  *eptypes.Object
+	ResponseGo2tsPayload *eptypes.Object
 
 	SwagComments []string
 
@@ -95,7 +95,7 @@ type Group struct {
 	RawPath, Path string
 	Dir           string
 	Placeholder   string
-	ParsedTypes   map[string]go2tstypes.Type
+	ParsedTypes   map[string]eptypes.Type
 
 	Children  []*Group
 	Endpoints []*Endpoint

--- a/samples/standard/clients/dart/classes/types.dart
+++ b/samples/standard/clients/dart/classes/types.dart
@@ -193,7 +193,7 @@ class PostCreateTableRequest {
   List<external_d8d61af.MultipartFile>? files;
   int flag;
   String id;
-  Map<int, int> map;
+  Map<int, int>? map;
   String text;
 
   PostCreateTableRequest({
@@ -201,7 +201,7 @@ class PostCreateTableRequest {
     this.files,
     this.flag = 0,
     this.id = '',
-    this.map = const {},
+    this.map,
     this.text = '',
   });
 
@@ -211,8 +211,10 @@ class PostCreateTableRequest {
           .fromJson(json['Flag']),
       id: const external_9298cca.DoNothingConverter<String>()
           .fromJson(json['ID']),
-      map: const external_9298cca.MapConverter<int, int, int>(
-              external_9298cca.DoNothingConverter<int>())
+      map: const external_9298cca
+                  .NullableConverter<Map<int, int>, Map<int, int>>(
+              external_9298cca.MapConverter<int, int, int>(
+                  external_9298cca.DoNothingConverter<int>()))
           .fromJson(json['map']),
       text: const external_9298cca.DoNothingConverter<String>()
           .fromJson(json['Text']),
@@ -223,8 +225,10 @@ class PostCreateTableRequest {
     return <String, dynamic>{
       'Flag': const external_9298cca.DoNothingConverter<int>().toJson(flag),
       'ID': const external_9298cca.DoNothingConverter<String>().toJson(id),
-      'map': const external_9298cca.MapConverter<int, int, int>(
-              external_9298cca.DoNothingConverter<int>())
+      'map': const external_9298cca
+                  .NullableConverter<Map<int, int>, Map<int, int>>(
+              external_9298cca.MapConverter<int, int, int>(
+                  external_9298cca.DoNothingConverter<int>()))
           .toJson(map),
       'Text': const external_9298cca.DoNothingConverter<String>().toJson(text),
     };

--- a/samples/standard/clients/ts/classes/types.ts
+++ b/samples/standard/clients/ts/classes/types.ts
@@ -16,7 +16,7 @@ export type PostCreateTableRequest = {
 	Flag: number;
 	ID: string;
 	Text: string;
-	map: {[key: number]: number};
+	map: {[key: number]: number} | null;
 }
 export type PostCreateTableResponse = {
 	ID: string;


### PR DESCRIPTION
and Add API_GEN_MAP_NON_NULLABLE to maintain backward compatibility

<!-- This is a template. Please rewrite to the necessary contents when creating the PR. -->
<!-- If there is an issue, enter it. -->
- Closes #280

<!-- ## Overview -->
<!-- Please write the purpose of this PR and the outline of implementation. -->
- 破壊的変更を含みます
- Goにおけるmap型はnullableですがgo-easyparserがnon-nullableとしてパースしていた問題の修正
    - API_GEN_MAP_NON_NULLABLE環境変数を1にすると従来通りmap型もnon-nullableとして出力する挙動を保つことができます
    - 新規プロジェクトにおいてはAPI_GEN_MAP_NON_NULLABLEは使用しないことを推奨します