### PR TITLE
ResponseやRequestの構造体のフィールドが空なとき、resp.text()を1回だけ実行する

### DIFF
--- a/pkg/client/typescript/templates/api.ts.tmpl
+++ b/pkg/client/typescript/templates/api.ts.tmpl
@@ -233,7 +233,6 @@ class {{ $elem.Name }} {
 {{- 	if eq .HasResFields true }}
 		const res = JSON.parse(responseText) as {{ $method.ResponseType }};
 {{- 	else }}
-		await resp.text();
 		const res = {} as {{ $method.ResponseType }};
 {{- 	end }}
 		context.response = res;

--- a/pkg/client/typescript/testdata/api_client.ts
+++ b/pkg/client/typescript/testdata/api_client.ts
@@ -810,7 +810,6 @@ class ServiceUser2Client {
 			await this.callMiddleware(this.afterMiddleware, context);
 			throw new ApiError(resp, responseText);
 		}
-		await resp.text();
 		const res = {} as ServiceUser2DeleteUserResponse;
 		context.response = res;
 		await this.callMiddleware(this.afterMiddleware, context);
@@ -1511,7 +1510,6 @@ class ServiceUserClient {
 			await this.callMiddleware(this.afterMiddleware, context);
 			throw new ApiError(resp, responseText);
 		}
-		await resp.text();
 		const res = {} as ServiceUserGetResponse;
 		context.response = res;
 		await this.callMiddleware(this.afterMiddleware, context);

--- a/samples/empty_root/clients/ts/api_client.ts
+++ b/samples/empty_root/clients/ts/api_client.ts
@@ -175,7 +175,6 @@ class FooBarClient {
 			await this.callMiddleware(this.afterMiddleware, context);
 			throw new ApiError(resp, responseText);
 		}
-		await resp.text();
 		const res = {} as FooBarPostUserResponse;
 		context.response = res;
 		await this.callMiddleware(this.afterMiddleware, context);

--- a/samples/standard/clients/ts/api_client.ts
+++ b/samples/standard/clients/ts/api_client.ts
@@ -810,7 +810,6 @@ class ServiceUser2Client {
 			await this.callMiddleware(this.afterMiddleware, context);
 			throw new ApiError(resp, responseText);
 		}
-		await resp.text();
 		const res = {} as ServiceUser2DeleteUserResponse;
 		context.response = res;
 		await this.callMiddleware(this.afterMiddleware, context);
@@ -1511,7 +1510,6 @@ class ServiceUserClient {
 			await this.callMiddleware(this.afterMiddleware, context);
 			throw new ApiError(resp, responseText);
 		}
-		await resp.text();
 		const res = {} as ServiceUserGetResponse;
 		context.response = res;
 		await this.callMiddleware(this.afterMiddleware, context);


### PR DESCRIPTION
<!-- This is a template. Please rewrite to the necessary contents when creating the PR. -->
<!-- If there is an issue, enter it. -->
- Closes #356 

<!-- ## Overview -->
<!-- Please write the purpose of this PR and the outline of implementation. -->
