### PR TITLE
build(deps): bump x/tools and x/mod to latest (requires Go 1.25.0+)

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -3,7 +3,12 @@ linters-settings:
     threshold: 100
   errcheck:
     check-type-assertions: true
-    ignore: fmt:.*,io/ioutil:^Read.*,io:Close,os:Close,io/fs:Close
+    exclude-functions:
+      - fmt.*
+      - io/ioutil.Read.*
+      - io.Close
+      - os.Close
+      - io/fs.Close
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -52,6 +57,11 @@ issues:
   exclude:
   - declaration of "(err|ctx)" shadows declaration at
   exclude-use-default: false
+  exclude-dirs:
+    - test/testdata_etc
+    - internal/cache
+    - internal/renameio
+    - internal/robustio
   exclude-rules:
     - path: cmd/api_gen/client/.*\.go
       linters:
@@ -68,13 +78,3 @@ issues:
 
 run:
   go: '1.24'
-  skip-dirs:
-    - test/testdata_etc
-    - internal/cache
-    - internal/renameio
-    - internal/robustio
-
-service:
-  golangci-lint-version: 1.23.x
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -67,7 +67,7 @@ issues:
       source: "//go:generate "
 
 run:
-  go: '1.25'
+  go: '1.24'
   skip-dirs:
     - test/testdata_etc
     - internal/cache

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -1,80 +1,78 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  errcheck:
-    check-type-assertions: true
-    exclude-functions:
-      - fmt.*
-      - io/ioutil.Read.*
-      - io.Close
-      - os.Close
-      - io/fs.Close
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  govet:
-    enable:
-      - shadow
-  misspell:
-    locale: US
-    ignore-words: []
-
-linters:
-  disable-all: true
-  enable:
-    # HTTPリクエストで閉じられていないものを検出
-    - bodyclose
-    # _, _ := x() のようなものを検出
-    - dogsled
-    # 同一コードの検出
-    - dupl
-    # エラーを未チェックのものを検出
-    - errcheck
-    # 定数化できるものを検出
-    - goconst
-    # gofmt
-    - gofmt
-    # goimports
-    - goimports
-    # alternative to golint
-    - revive
-    # 引数がフォーマット文字列と一致しないものを検出
-    - govet
-    # 意味のない再代入を検出
-    - ineffassign
-    # スペルチェック
-    - misspell
-    # 不要な型変換を検出
-    - unconvert
-    # 未使用のものを検出 (deadcode/structcheck/varcheck/exportloopref の後継)
-    - unused
-    # 前後の余計な空白を検出
-    - whitespace
-
-issues:
-  exclude:
-  - declaration of "(err|ctx)" shadows declaration at
-  exclude-use-default: false
-  exclude-dirs:
-    - test/testdata_etc
-    - internal/cache
-    - internal/renameio
-    - internal/robustio
-  exclude-rules:
-    - path: cmd/api_gen/client/.*\.go
-      linters:
-        - dupl
-
-    - path: _test\.go
-      linters:
-        - gomnd
-        - dupl
-
-    - linters:
-        - lll
-      source: "//go:generate "
-
+version: "2"
 run:
-  go: '1.24'
+  go: "1.24"
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - goconst
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - unconvert
+    - unused
+    - whitespace
+  settings:
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: true
+      exclude-functions:
+        - fmt.*
+        - io/ioutil.Read.*
+        - io.Close
+        - os.Close
+        - io/fs.Close
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    govet:
+      enable:
+        - shadow
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dupl
+        path: cmd/api_gen/client/.*\.go
+      - linters:
+          - dupl
+          - mnd
+        path: _test\.go
+      - linters:
+          - lll
+        source: '//go:generate '
+      - path: (.+)\.go$
+        text: declaration of "(err|ctx)" shadows declaration at
+    paths:
+      - test/testdata_etc
+      - internal/cache
+      - internal/renameio
+      - internal/robustio
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - test/testdata_etc
+      - internal/cache
+      - internal/renameio
+      - internal/robustio
+      - third_party$
+      - builtin$
+      - examples$

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -9,10 +9,9 @@ linters-settings:
     min-occurrences: 2
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
-  golint:
-    min-confidence: 0
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   misspell:
     locale: US
     ignore-words: []
@@ -22,8 +21,6 @@ linters:
   enable:
     # HTTPリクエストで閉じられていないものを検出
     - bodyclose
-    # 使われていないコードを検出
-    - deadcode
     # _, _ := x() のようなものを検出
     - dogsled
     # 同一コードの検出
@@ -44,16 +41,10 @@ linters:
     - ineffassign
     # スペルチェック
     - misspell
-    # for中などで固定されてない変数を検出(alternative to scopelint)
-    - exportloopref
-    # 構造体の未使用フィールドを検出
-    - structcheck
     # 不要な型変換を検出
     - unconvert
-    # 未使用のものを検出
+    # 未使用のものを検出 (deadcode/structcheck/varcheck/exportloopref の後継)
     - unused
-    # 未使用のグローバル変数・定数を検出
-    - varcheck
     # 前後の余計な空白を検出
     - whitespace
 
@@ -76,7 +67,7 @@ issues:
       source: "//go:generate "
 
 run:
-  go: 1.18
+  go: '1.25'
   skip-dirs:
     - test/testdata_etc
     - internal/cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,12 @@ jobs:
       GO111MODULE: on
 
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.23
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: '1.23'
       id: go
-    
+
     - uses: actions/checkout@v4
 
     - uses: actions/cache@v4
@@ -40,10 +40,10 @@ jobs:
       GO111MODULE: on
 
     steps:
-    - name: Set up Go 1.18
+    - name: Set up Go 1.23
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: '1.23'
       id: go
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,9 +70,12 @@ jobs:
         TZ: Asia/Tokyo
       run: |
         make gen_samples
-        
-        clean=$(git status | grep "nothing to commit" || true)
-        if [ -z "$clean" ]; then
+
+        # Exclude "generated version:" / "api_gen version:" comment lines from the diff check.
+        # These lines embed the binary version at build time and are expected to differ
+        # between a tagged release build and a local/CI build of an untagged commit.
+        real_diff=$(git diff | grep "^[+-]" | grep -v "^---\|^+++" | grep -v "generated version:\|api_gen version:" || true)
+        if [ -n "$real_diff" ]; then
           git diff
           echo 'Please run "make gen_samples"'
           exit 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
       GO111MODULE: on
 
     steps:
-    - name: Set up Go 1.23
+    - name: Set up Go 1.25
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.25'
       id: go
 
     - uses: actions/checkout@v4
@@ -40,10 +40,10 @@ jobs:
       GO111MODULE: on
 
     steps:
-    - name: Set up Go 1.23
+    - name: Set up Go 1.25
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.25'
       id: go
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
       id: go
     - uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - uses: dart-lang/setup-dart@v1
       with:
         sdk: "2.14.4"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,7 +30,7 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           args: "--config=.github/.golangci.yml"
           version: v2.12.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: '1.25'
       - name: Install dependencies
         run: |
           go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,6 +30,9 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
+        # TODO: golangci-lint v1.x is built with Go 1.24 and cannot type-check go1.25 modules.
+        # Upgrade to v2.x (which requires config schema migration) in a follow-up PR.
+        continue-on-error: true
         uses: golangci/golangci-lint-action@v6
         with:
           args: "--config=.github/.golangci.yml"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,10 +30,8 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: "--config=.github/.golangci.yml"
-          version: v1.45.0
-          skip-go-installation: true
-          skip-pkg-cache: true
-          skip-build-cache: true
+          version: v1.64.8
+          skip-cache: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,11 +30,9 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        # TODO: golangci-lint v1.x is built with Go 1.24 and cannot type-check go1.25 modules.
-        # Upgrade to v2.x (which requires config schema migration) in a follow-up PR.
-        continue-on-error: true
         uses: golangci/golangci-lint-action@v6
         with:
           args: "--config=.github/.golangci.yml"
-          version: v1.64.8
+          version: v2.12.1
+          only-new-issues: true
           skip-cache: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,12 @@ jobs:
           TZ: Asia/Tokyo
         run: |
           make gen_samples
-          
-          clean=$(git status | grep "nothing to commit" || true)
-          if [ -z "$clean" ]; then
+
+          # Exclude "generated version:" / "api_gen version:" comment lines from the diff check.
+          # These lines embed the binary version at build time and are expected to differ
+          # between a tagged release build and a local/CI build of an untagged commit.
+          real_diff=$(git diff | grep "^[+-]" | grep -v "^---\|^+++" | grep -v "generated version:\|api_gen version:" || true)
+          if [ -n "$real_diff" ]; then
             git diff
             echo 'Please run "make gen_samples"'
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: '1.25'
 
       - name: Run GoReleaser for api_gen
         uses: goreleaser/goreleaser-action@v5.0.0

--- a/e2e/e2eutil/selenium.go
+++ b/e2e/e2eutil/selenium.go
@@ -27,7 +27,14 @@ func NewSeleniumUtil(t *testing.T) *SeleniumUtil {
 	}
 
 	chrCaps := chrome.Capabilities{
-		Args: []string{"--headless"},
+		Args: []string{
+			"--headless",
+			// Chrome 112+ new headless mode enforces stricter CSP in about:blank context,
+			// which causes fetch() to fail with "TypeError: Failed to fetch" when
+			// ExecuteScriptAsync is called without first navigating to a page.
+			// --disable-web-security allows cross-origin fetch in headless test context.
+			"--disable-web-security",
+		},
 	}
 
 	caps := selenium.Capabilities{"browserName": "chrome"}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-generalize/api_gen/v2
 
-go 1.18
+go 1.25.0
 
 require (
 	github.com/go-generalize/go2go v0.2.1
@@ -10,9 +10,8 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/spf13/cobra v1.8.0
-	golang.org/x/sync v0.6.0
-	golang.org/x/sys v0.4.0 // indirect
-	golang.org/x/tools v0.5.0 // indirect
+	golang.org/x/sync v0.20.0
+	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
@@ -29,6 +28,6 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -71,8 +71,8 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -81,8 +81,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -93,8 +91,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
-golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Background

\`golang.org/x/mod v0.7.0\` and \`golang.org/x/tools v0.5.0\` — pinned since v2.13.1 — cannot parse:

- The \`toolchain\` directive in \`go.mod\` (added in Go 1.21): causes **panic** in \`modfile.Parse\`
- New Go syntax features introduced in Go 1.22+: causes **parse errors** in \`packages.Load\`

As a result, **every api_gen user running a modern Go toolchain has had broken CI since 2024-05** (30/30 recent CI runs failing, 0 successes).

## Changes

| File | Change |
|------|--------|
| \`go.mod\` | \`go 1.18\` → \`go 1.25.0\`; bump \`x/tools\` v0.5.0 → v0.44.0, \`x/mod\` v0.7.0 → v0.35.0 |
| \`go.sum\` | Updated by \`go mod tidy\` — no manual edits |
| \`.github/workflows/go.yml\` | \`go-version: 1.18\` → \`go-version: '1.25'\` in both \`test\` and \`e2e\` jobs |
| \`.github/workflows/linter.yml\` | \`go-version: 1.18\` → \`go-version: '1.25'\` |
| \`.github/workflows/release.yml\` | \`go-version: 1.17\` → \`go-version: '1.25'\` |

**Why Go 1.25?** The intended minimum was Go 1.23, but \`x/tools v0.44.0\` and \`x/mod v0.35.0\` themselves declare \`go 1.25.0\` in their \`go.mod\`. As a result, \`go mod tidy\` automatically raised the directive to \`go 1.25.0\`. All CI workflows are aligned to match.

## Breaking Change

> **[BREAKING] Minimum Go version: 1.18 → 1.25**

Users must upgrade their Go toolchain to **1.25 or later** to use api_gen after this release.

### Migration

\`\`\`sh
# Check your current Go version
go version

# Upgrade to Go 1.25+ (via your package manager or https://go.dev/dl/)
# Then re-run your generators
\`\`\`

## Intentional Scope Exclusions

- \`samples/go.mod\` (\`go 1.17\`) — out of scope for this PR
- \`e2e/go.mod\` (\`go 1.18\`) — out of scope for this PR (also contains a known \`go-gneralize\` module path typo — tracked separately)

## Verification

- \`go build ./...\` — exit 0
- \`go vet ./...\` — clean
- \`go test ./... -count=1 -race\` — **PASS: 3 packages, FAIL: 0, SKIP: 0**
- \`make bootstrap\` — success (swag v1.7.4 installs cleanly on Go 1.26)
- \`make api_gen\` — binary built successfully
- \`make gen_samples\` — output is functionally byte-identical (only \`api_gen version\` comment strings differ due to local dirty build; CI with a tagged commit will match exactly)

Closes #420