### PR TITLE
chore(ci): pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
     - name: Set up Go 1.25
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.25'
       id: go
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -41,20 +41,20 @@ jobs:
 
     steps:
     - name: Set up Go 1.25
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.25'
       id: go
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '20'
-    - uses: dart-lang/setup-dart@v1
+    - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       with:
         sdk: "2.14.4"
-    - uses: nanasess/setup-chromedriver@v2.2.2
-    - uses: actions/checkout@v4
+    - uses: nanasess/setup-chromedriver@42cc2998329f041de87dc3cfa33a930eacd57eaa # v2.2.2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -63,7 +63,7 @@ jobs:
 
     - name: Run E2E tests
       run: |
-        make e2e       
+        make e2e
 
     - name: Ensure samples are generated
       env:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           args: "--config=.github/.golangci.yml"
           version: v2.12.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
 
       - name: Run GoReleaser for api_gen
-        uses: goreleaser/goreleaser-action@v5.0.0
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
## Summary

Pin every GitHub Actions reference in `.github/workflows/` to a full 40-character commit SHA, following GitHub's [hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). This protects against supply-chain attacks where a Git tag could be silently re-pointed to a malicious commit.

## Why

Third-party actions (and even first-party ones) are pinned by tag (`@v4`) by default, but Git tags are mutable. A compromised maintainer or a successful credential-theft can repoint a tag to malicious code, and every CI run pulling `@v4` would silently execute it. Pinning to a commit SHA makes this impossible — the SHA is content-addressed.

## Changes

| Action | Tag | Pinned SHA |
|--------|-----|------------|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-go` | v5.6.0 | `40f1582b2485089dde7abd97c1529aa768e1baff` |
| `actions/cache` | v4.3.0 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/setup-node` | v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `dart-lang/setup-dart` | v1.7.2 | `65eb853c7ba17dde3be364c3d2858773e7144260` |
| `nanasess/setup-chromedriver` | v2.2.2 | `42cc2998329f041de87dc3cfa33a930eacd57eaa` |
| `golangci/golangci-lint-action` | v7.0.1 | `9fae48acfc02a90574d7c304a1758ef9895495fa` |
| `goreleaser/goreleaser-action` | v5.0.0 | `7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8` |

Files touched:
- `.github/workflows/go.yml`
- `.github/workflows/linter.yml`
- `.github/workflows/release.yml`

## Test plan

- [x] `grep -E "@[0-9a-f]{40}" .github/workflows/*.yml` shows every `uses:` line pinned to a full SHA
- [x] SHA pin 漏れゼロを確認（`grep -v "@[0-9a-f]{40}"` で 0 件）
- [x] CI passes (test / linter / e2e)