### PR TITLE
fix(ci): replace deprecated --rm-dist with --clean for goreleaser v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: cmd/api_gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow has been silently broken since goreleaser v2.0.0 was published.

\`goreleaser-action@v5.0.0\` always downloads the **latest** goreleaser binary, so as soon as goreleaser v2 became latest, every push of a tag matching \`v[0-9]+.[0-9]+.[0-9]+*\` started running:

\`\`\`
goreleaser release --rm-dist
\`\`\`

…which fails with \`unknown flag: --rm-dist\`. The flag was deprecated in goreleaser v1.21 and removed in v2.0.0. The replacement is \`--clean\`.

## Impact

\`v2.14.0\` was tagged and a GitHub Release was created (manually by Diamond Dogs after PR #421 / #422 merge), but the \`release\` workflow that publishes prebuilt binaries failed on the same push event. As a result, \`v2.14.0\` has **0 binary assets** (cf. \`v2.13.1\` which has 7).

## Fix

One-line change:

\`\`\`diff
- args: release --rm-dist
+ args: release --clean
\`\`\`

## Follow-up (out of scope)

The release manager will decide whether to:
1. Force re-tag \`v2.14.0\` to re-trigger the workflow (risky for module proxy caches)
2. Cut a fresh \`v2.14.1\` patch tag once this PR merges (safer)

Tracked via internal coordination.

## Test plan

- [x] grep confirms only \`release.yml\` line is changed
- [ ] Once merged, the next tag push will trigger goreleaser v2 with \`--clean\` and produce binary assets