### PR TITLE
chore(ci): migrate .goreleaser.yml to goreleaser v2 schema

### DIFF
--- a/cmd/api_gen/.goreleaser.yml
+++ b/cmd/api_gen/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: api_gen
 
 env:
@@ -20,16 +22,16 @@ builds:
       - arm64
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- with .Arm }}v{{ . }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary

Companion to #426. After fixing the \`--rm-dist\` flag in the workflow, the goreleaser v2 binary still rejects this repo's \`.goreleaser.yml\` because of two v2 deprecations:

1. \`archives.replacements\` was **removed** in goreleaser v2.0 (deprecated since v1.14)
2. \`archives.format_overrides[].format\` was **deprecated** in v2.6 in favor of \`formats: [...]\`

This PR migrates \`.goreleaser.yml\` to the v2 schema while keeping archive names byte-identical to v2.13.1.

## Changes

- Add \`version: 2\` (required by goreleaser v2)
- Drop \`archives.replacements\` block (the noop \`darwin/linux/windows\` mappings, plus the meaningful \`amd64 -> x86_64\` / \`386 -> i386\`)
- Express \`amd64 -> x86_64\` / \`386 -> i386\` inside \`name_template\` using a Go template \`if/else\` chain
- \`format_overrides[].format: zip\` -> \`formats: [zip]\`

## Why

Without this PR, the next tag push (v2.14.1) would fail in goreleaser v2 with \`unknown field \`replacements\`\`, repeating the failure pattern seen on v2.14.0 (zero binary assets).

## Verification

- Archive name template still produces the v2.13.1-compatible names: \`api_gen_linux_x86_64.tar.gz\`, \`api_gen_windows_arm64.zip\`, etc.
- goreleaser v2 will accept the file (no \`replacements\` warnings).

## Follow-up

Once this merges, cut **v2.14.1** to actually publish binaries.